### PR TITLE
Expand @ parameters correctly

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -246,7 +246,7 @@ def printTraceStatement(msg):
 def expandCommandLine(cmdline):
     ret = []
             
-    for arg in cmdline[0:]:
+    for arg in cmdline:
         if arg[0] == '@':
             includeFile = arg[1:]
             f = open(includeFile, 'r')
@@ -293,7 +293,7 @@ def analyzeCommandLine(cmdline):
 
 
 def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False):
-    realCmdline = [compilerBinary] + cmdLine[0:]
+    realCmdline = [compilerBinary] + cmdLine
     
     returnCode = None
     output = None


### PR DESCRIPTION
The existing code seems to assume that @ parameters contain only source files, as it exits out saying that there are multiple source files. In our environment, we have files containing include paths and other parameters that we include using @. The code change will expand these parameters correctly.
