### PR TITLE
directory in /Fo and a little more trace output

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -440,6 +440,7 @@ if "CLCACHE_DISABLE" in os.environ:
 printTraceStatement("Parsing given commandline '%s'" % sys.argv[1:] )
 
 cmdLine = expandCommandLine(sys.argv[1:])
+printTraceStatement("Expanded commandline '%s'" % cmdLine )
 analysisResult, sourceFile, outputFile = analyzeCommandLine(cmdLine)
 
 cache = ObjectCache()


### PR DESCRIPTION
Hi!

There are two small commits in my fork that might be useful.

BTW, are there any plans to support multi-file compilations (without linking)? qmake generates Makefiles that compile multiple objects in one run and that is quite useful for taking advantage of multiple cores during compilation. 

Still, obviously, having a compiler cache with that would be even better... It probably would need to check all objects to be generated, take the valid existing ones from the cache and invoke the compiler for the remaining ones.

Regards,

Tilman
