### PR TITLE
Don't analyze source files if link option is specified

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -358,6 +358,9 @@ def analyzeCommandLine(cmdline):
         sourceFiles += options['Tc']
         compl = True
 
+    if 'link' in options or not 'c' in options:
+        return AnalysisResult.CalledForLink, None, None
+
     if len(sourceFiles) == 0:
         return AnalysisResult.NoSourceFile, None, None
 
@@ -365,9 +368,6 @@ def analyzeCommandLine(cmdline):
         if compl:
             return AnalysisResult.MultipleSourceFilesComplex, None, None
         return AnalysisResult.MultipleSourceFilesSimple, sourceFiles, None
-
-    if 'link' in options or not 'c' in options:
-        return AnalysisResult.CalledForLink, None, None
 
     outputFile = None
     if 'Fo' in options:


### PR DESCRIPTION
This change fixes an issue with clcache trying to incorrectly reinvoke itself when one object file and multiple library files given for link resulting in errors about missing source files from `cl`. Since clcache calls `cl` for linking there is no point in analyzing source files if link option is specified.
