### PR TITLE
use md5 for hashing

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -146,7 +146,8 @@ class ObjectCache:
         return h.hexdigest()
 
     def hasEntry(self, key):
-        return os.path.exists(self.cachedObjectName(key))
+        with self.lock:
+            return os.path.exists(self.cachedObjectName(key))
 
     def setEntry(self, key, objectFileName, compilerOutput):
         with self.lock:


### PR DESCRIPTION
Use md5 as it is about 20% faster than sha1. while md5 is not a good secure hash function it is more than good enough for a uniqueness value
