### PR TITLE
Ensure the destination folder exists

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -31,6 +31,7 @@ from ctypes import windll, wintypes
 import codecs
 from collections import defaultdict, namedtuple
 import cPickle as pickle
+import errno
 import hashlib
 import json
 import os
@@ -477,6 +478,13 @@ def getHash(data):
 
 
 def copyOrLink(srcFilePath, dstFilePath):
+    # Ensure the destination folder exists
+    try:
+        os.makedirs(os.path.dirname(dstFilePath))
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
     if "CLCACHE_HARDLINK" in os.environ:
         ret = windll.kernel32.CreateHardLinkW(unicode(dstFilePath), unicode(srcFilePath), None)
         if ret != 0:


### PR DESCRIPTION
With this change, destination folders are created.

When a destination file is e.g. `build\obj\lib\asn1_oid_lookup_default.obj` and I remove the entire directory `build\obj`, the script will now create `build\obj\lib` before copying the object.

This is very useful when you have build folders that can be deleted entirely or you build in-tree and perform a git clean (like our CI does). Necessary for re-building Botan.