### PR TITLE
Set default cache size to 1 GiB

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -45,8 +45,8 @@ Options
     Doesn't actually clear the cache, so the number of cached objects and the
     cache size will remain unchanged.
 -M <size>::
-    Sets the maximum size of the cache in bytes. The default is 1048576000
-    Bytes.
+    Sets the maximum size of the cache in bytes.
+    The default value is 1073741824 (1 GiB).
 
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/clcache.py
+++ b/clcache.py
@@ -320,7 +320,7 @@ class PersistentJSONDict:
 
 
 class Configuration:
-    _defaultValues = {"MaximumCacheSize": 1024 * 1024 * 1000}
+    _defaultValues = {"MaximumCacheSize": 1073741824} # 1 GiB
 
     def __init__(self, objectCache):
         self._objectCache = objectCache


### PR DESCRIPTION
This helps readers to understand the default value of the cache size in the README