### PR TITLE
Make clcache compatible with Python 3

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -15,6 +15,8 @@ relay the invocation to the real 'cl.exe' program.
 Installation
 ~~~~~~~~~~~~
 
+Python 2.7 or Python 3.3+ is required.
+
 The source code comes with a small http://www.py2exe.org/[py2exe] script which
 makes it easy to compile the Python code into an executable. You can generate
 an executable on your system by running


### PR DESCRIPTION
This PR makes clcache compatible with Python 2.7 and Python 3.

The changes are minimal and can be considered good style even for Python 2. Most work was done using the 2to3 tool (fixing `print` statements and stuff like `dict.items()`).

For the `wintypes.c_int` there is a public alias which is can be used in both Python 2 and Python 3.

Some changes are required because Python 3 strictly differentiates between unicode strings and byte arrays. E.g. string must be encoded before they can be hashed.

I change the fallback of command line file encoding to UTF-8, which is used in my JOM+CMake setup. I think it is a better fallback than just pass raw bytes because it handles UTF-8 and ASCII files correctly. 

Credit goes to @cemehehko for the pickel block.

Tested using Python 2.7 and Python 3.4

Closes #26