### PR TITLE
Make json format in stats.txt better human-readable

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -325,7 +325,8 @@ class PersistentJSONDict:
 
     def save(self):
         if self._dirty:
-            json.dump(self._dict, open(self._fileName, 'w'))
+            json.dump(self._dict, open(self._fileName, 'w'),
+                      sort_keys=True, indent=4)
 
     def __setitem__(self, key, value):
         self._dict[key] = value


### PR DESCRIPTION
This changes the json in stats.txt from a one-liner to something nicely readable like

```
{
    "CacheEntries": 141,
    "CacheHits": 1385,
    "CacheMisses": 141,
    "CacheSize": 74040145,
    "CallsForLinking": 52,
    "CallsWithMultipleSourceFiles": 0,
    "CallsWithPch": 0,
    "CallsWithoutSourceFile": 0,
    "EvictedMisses": 0,
    "HeaderChangedMisses": 0,
    "SourceChangedMisses": 72
}
```

Reading from any json style and writing to the pretty style does not break anything.