### PR TITLE
Fix bug when object file was specified without directory

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -502,7 +502,7 @@ def getHash(data):
 def copyOrLink(srcFilePath, dstFilePath):
     # Ensure the destination folder exists
     try:
-        os.makedirs(os.path.dirname(dstFilePath))
+        os.makedirs(os.path.dirname(os.path.abspath(dstFilePath)))
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise

--- a/tests.py
+++ b/tests.py
@@ -54,5 +54,20 @@ class TestCompileRuns(unittest.TestCase):
         output = subprocess.check_output(cmd).decode("ascii").strip()
         self.assertEqual(output, "0 1 1 2 3 5 8 13 21 34 55 89 144 233 377")
 
+    def testRecompile(self):
+        cmd = [self.PYTHON_BINARY, "clcache.py", "/nologo", "/EHsc", "/c", "tests\\recompile1.cpp"]
+        subprocess.check_call(cmd) # Compile once
+        subprocess.check_call(cmd) # Compile again
+
+    def testRecompileObjectSetSameDir(self):
+        cmd = [self.PYTHON_BINARY, "clcache.py", "/nologo", "/EHsc", "/c", "tests\\recompile2.cpp", "/Forecompile2_custom_object_name.obj"]
+        subprocess.check_call(cmd) # Compile once
+        subprocess.check_call(cmd) # Compile again
+
+    def testRecompileObjectSetOtherDir(self):
+        cmd = [self.PYTHON_BINARY, "clcache.py", "/nologo", "/EHsc", "/c", "tests\\recompile3.cpp", "/Fotests\\output\\recompile2_custom_object_name.obj"]
+        subprocess.check_call(cmd) # Compile once
+        subprocess.check_call(cmd) # Compile again
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/recompile1.cpp
+++ b/tests/recompile1.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Sample file for recompile test." << std::endl;
+    return 0;
+}

--- a/tests/recompile2.cpp
+++ b/tests/recompile2.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Sample file for recompile test." << std::endl;
+    std::cout << "This time we set a specific object file in the same dir" << std::endl;
+    return 0;
+}

--- a/tests/recompile3.cpp
+++ b/tests/recompile3.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Sample file for recompile test." << std::endl;
+    std::cout << "This time we set a specific object file in another dir" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Recompiling the same file currently fails on my machine, so let's add a test for that