### PR TITLE
Random thoughts on #31

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -551,14 +551,19 @@ def printTraceStatement(msg):
         print(os.path.join(script_dir, "clcache.py") + " " + msg)
 
 
-def extractArgument(line, start, end):
+def extractArgument(argument):
     # If there are quotes from both sides of argument, remove them
     # "-Isome path" must becomse -Isome path
-    if line[start] == '"' and line[end - 1] == '"' and start != (end - 1):
-        start += 1
-        end -= 1
-    # Unescape quotes.
-    return line[start:end].replace('\\"', '"').strip()
+    if not argument:
+        return ""
+
+    if argument == '"':
+        raise Exception("Invalid argument: '\"'")
+
+    if argument[0] == '"' and argument[-1] == '"':
+        argument = argument[1:-1] # Cut first and last character
+
+    return argument.strip()
 
 
 def splitCommandsFile(line):
@@ -573,7 +578,7 @@ def splitCommandsFile(line):
     result = []
     while i < len(line):
         if line[i] == ' ' and not insideQuotes and wordStart >= 0:
-            result.append(extractArgument(line, wordStart, i))
+            result.append(extractArgument(line[wordStart:i]))
             wordStart = -1
         if line[i] == '"' and ((i == 0) or (i > 0 and line[i - 1] != '\\')):
             insideQuotes = not insideQuotes
@@ -582,7 +587,7 @@ def splitCommandsFile(line):
         i += 1
 
     if wordStart >= 0:
-        result.append(extractArgument(line, wordStart, len(line)))
+        result.append(extractArgument(line[wordStart:]))
     return result
 
 


### PR DESCRIPTION
This removed the replacement from `\"` to `"` in extractArgument, which should solve #31.

Note that Python strings having the prefix `r` no not use the backslash notation to escape a special char, so `r'\t'` is `\` and `t`, not a tab. Github messes up with syntax highlighting here.