### PR TITLE
Test precompiled headers with clcache

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -681,7 +681,7 @@ def analyzeCommandLine(cmdline):
     # copy the generated .pdb files into/out of the cache.
     if 'Zi' in options:
         return AnalysisResult.ExternalDebugInfo, None, None
-    if 'Yu' in options:
+    if 'Yc' in options or 'Yu' in options:
         return AnalysisResult.CalledWithPch, None, None
     if 'Tp' in options:
         sourceFiles += options['Tp']

--- a/tests/precompiled-headers/Makefile
+++ b/tests/precompiled-headers/Makefile
@@ -1,0 +1,35 @@
+OBJS = myapp.obj applib.obj
+APP = myapp.exe
+
+# List all stable header files in the STABLEHDRS macro.
+STABLEHDRS = stable.h another.h
+
+# List the final header file to be precompiled here:
+BOUNDRY = stable.h
+
+# List header files under development here:
+UNSTABLEHDRS = unstable.h
+
+CPPFLAGS  = /nologo /EHsc /c /W3 /Gs /MT
+LINKFLAGS =
+LIBS      =
+
+$(APP): $(OBJS)
+    link $(LINKFLAGS) /OUT:$(APP) $(OBJS) $(LIBS)
+
+# Compile myapp
+myapp.obj  : myapp.cpp $(UNSTABLEHDRS)  stable.pch
+    $(CPP) $(CPPFLAGS) /Yu$(BOUNDRY) myapp.cpp
+
+# Compile applib
+#the_applib.obj : applib.cpp $(UNSTABLEHDRS) stable.pch
+#    $(CPP) $(CPPFLAGS) /Yu$(BOUNDRY) /Fothe_applib.obj applib.cpp
+
+# Compile headers
+stable.pch : $(STABLEHDRS)
+    $(CPP) $(CPPFLAGS) /Yc$(BOUNDRY) applib.cpp
+
+.PHONY: clean
+
+clean:
+    rm -f $(OBJS) $(APP) stable.pch

--- a/tests/precompiled-headers/README.txt
+++ b/tests/precompiled-headers/README.txt
@@ -1,0 +1,12 @@
+This is a sample project to test creating and using (/Yc and /Yu)
+of precompiled headers.
+
+It is based on "Example Code for PCH" and "Sample Makefile for PCH":
+* https://msdn.microsoft.com/en-us/library/de9s74bh.aspx
+* https://msdn.microsoft.com/en-us/library/d9b6wk21.aspx
+The tutorial was writte a decade ago using MSVC 2005, so the author
+had to adjust a lot of things to make it run using modern compilers.
+
+It is suspected that the original content from Microsoft does not
+satisfy the threshold of originality. All modifications are licensed
+the same way as the rest of the clcache project.

--- a/tests/precompiled-headers/another.h
+++ b/tests/precompiled-headers/another.h
@@ -1,0 +1,10 @@
+// ANOTHER.H : Contains the interface to code that is not
+//             likely to change.
+//
+#ifndef ANOTHER_H
+#define ANOTHER_H
+
+#include <iostream>
+void savemoretime( void );
+
+#endif // ANOTHER_H

--- a/tests/precompiled-headers/applib.cpp
+++ b/tests/precompiled-headers/applib.cpp
@@ -1,0 +1,29 @@
+// APPLIB.CPP : This file contains the code that implements
+//              the interface code declared in the header
+//              files STABLE.H, ANOTHER.H, and UNSTABLE.H.
+//
+#include "another.h"
+#include "stable.h"
+#include "unstable.h"
+
+// The following code represents code that is deemed stable and
+// not likely to change. The associated interface code is
+// precompiled. In this example, the header files STABLE.H and
+// ANOTHER.H are precompiled.
+void savetime( void )
+{
+    std::cout << "Why recompile stable code?" << std::endl;
+}
+
+void savemoretime( void )
+{
+    std::cout << "Why, indeed?" << std::endl;
+}
+
+// The following code represents code that is still under
+// development. The associated header file is not precompiled.
+void notstable( void )
+{
+    std::cout << "Unstable code requires"
+              << " frequent recompilation." << std::endl;
+}

--- a/tests/precompiled-headers/myapp.cpp
+++ b/tests/precompiled-headers/myapp.cpp
@@ -1,0 +1,18 @@
+// MYAPP.CPP : Sample application
+//             All precompiled code other than the file listed
+//             in the makefile's BOUNDRY macro (stable.h in
+//             this example) must be included before the file
+//             listed in the BOUNDRY macro. Unstable code must
+//             be included after the precompiled code.
+//
+#include "another.h"
+#include "stable.h"
+#include "unstable.h"
+
+int main()
+{
+    savetime();
+    savemoretime();
+    notstable();
+    return 0;
+}

--- a/tests/precompiled-headers/stable.h
+++ b/tests/precompiled-headers/stable.h
@@ -1,0 +1,11 @@
+// STABLE.H : Contains the interface to code that is not likely
+//            to change. List code that is likely to change
+//            in the makefile's STABLEHDRS macro.
+//
+#ifndef STABLE_H
+#define STABLE_H
+
+#include <iostream>
+void savetime( void );
+
+#endif // STABLE_H

--- a/tests/precompiled-headers/unstable.h
+++ b/tests/precompiled-headers/unstable.h
@@ -1,0 +1,13 @@
+// UNSTABLE.H : Contains the interface to code that is
+//              likely to change. As the code in a header
+//              file becomes stable, remove the header file
+//              from the makefile's UNSTABLEHDR macro and list
+//              it in the STABLEHDRS macro.
+//
+#ifndef UNSTABLE_H
+#define UNSTABLE_H
+
+#include <iostream>
+void notstable( void );
+
+#endif // UNSTABLE_H


### PR DESCRIPTION
This passes all calls including `/Yc` and `/Yu` to the real compiler, allowing the use of clcache in a mixed environment, where compilation units without precompiled headers use the cache and compilation units with precompiled headers don't.

I was able to reproduce the bug described in #21 using a `nmake`, `nmake clean`, `nmake` on the sample project. Only the second nmake build failed because the .pch file was missing. This is because clcache used the object from cache, which did not restore the .pch file. With the patch in place, the test passes.

Closes #21