### PR TITLE
Fix /MP[processMax] parsing

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -797,7 +797,7 @@ def jobCount(cmdLine):
 
     switches.extend(cmdLine)
 
-    mp_switch = [switch for switch in switches if re.search(r'^/MP\d+$', switch) is not None]
+    mp_switch = [switch for switch in switches if re.search(r'^/MP(\d+)?$', switch) is not None]
     if len(mp_switch) == 0:
         return 1
 

--- a/clcache.py
+++ b/clcache.py
@@ -797,12 +797,12 @@ def jobCount(cmdLine):
 
     switches.extend(cmdLine)
 
-    mp_switch = [switch for switch in switches if re.search(r'^/MP(\d+)?$', switch) is not None]
-    if len(mp_switch) == 0:
+    mp_switches = [switch for switch in switches if re.search(r'^/MP(\d+)?$', switch) is not None]
+    if len(mp_switches) == 0:
         return 1
 
     # the last instance of /MP takes precedence
-    mp_switch = mp_switch.pop()
+    mp_switch = mp_switches.pop()
 
     count = mp_switch[3:]
     if count != "":


### PR DESCRIPTION
Fixes a bug in the regular expression for `/MP[processMax]`. Before the integer was not optional, so `/MP` was not interpreted as an mp switch and thus

```
    # /MP, but no count specified; use CPU count
    try:
        return multiprocessing.cpu_count()
    except:
        # not expected to happen
        return 2
```

was dead code.

This renames `mp_switch` to `mp_switches` in the implementation because it is a list of switches and should not be confused with the chosen switch `mp_switch`.