### PR TITLE
Add initial hit test

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -866,13 +866,23 @@ def reinvokePerSourceFile(cmdLine, sourceFiles):
 
     return runJobs(commands, jobCount(cmdLine))
 
+def getConfiguration():
+    cache = ObjectCache()
+    with cache.lock:
+        config = Configuration(cache)
+    return config
 
-def printStatistics():
+def getStatistics():
     cache = ObjectCache()
     with cache.lock:
         stats = CacheStatistics(cache)
-        cfg = Configuration(cache)
-        out = """clcache statistics:
+    return stats
+
+def printStatistics():
+    cache = ObjectCache()
+    cfg = getConfiguration()
+    stats = getStatistics()
+    out = """clcache statistics:
   current cache dir        : {}
   cache size               : {:,} bytes
   maximum cache size       : {:,} bytes

--- a/tests.py
+++ b/tests.py
@@ -142,6 +142,18 @@ class TestCompileRuns(unittest.TestCase):
         subprocess.check_call(cmd) # Compile once
         subprocess.check_call(cmd) # Compile again
 
+class TestHits(unittest.TestCase):
+    PYTHON_BINARY = sys.executable
+
+    def testHitsSimple(self):
+        cmd = [self.PYTHON_BINARY, "clcache.py", "/nologo", "/EHsc", "/c", r'tests\hits-and-misses\hit.cpp']
+        subprocess.check_call(cmd) # Ensure it has been compiled before
+
+        oldHits = clcache.getStatistics().numCacheHits()
+        subprocess.check_call(cmd) # This must hit now
+        newHits = clcache.getStatistics().numCacheHits()
+        self.assertEqual(newHits, oldHits + 1)
+
 class TestPrecompiledHeaders(unittest.TestCase):
     PYTHON_BINARY = sys.executable
     CLCACHE_SCRIPT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "clcache.py")

--- a/tests/hits-and-misses/hit.cpp
+++ b/tests/hits-and-misses/hit.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "A C++ file we compile twice and expect a hit" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This adds a first test that ensures that an object which should be in the cache is hit when compiled again.