### PR TITLE
Replace command 'rm' by 'del'

### DIFF
--- a/tests/precompiled-headers/Makefile
+++ b/tests/precompiled-headers/Makefile
@@ -1,3 +1,5 @@
+RM = @del /q
+
 OBJS = myapp.obj applib.obj
 APP = myapp.exe
 
@@ -32,4 +34,4 @@ stable.pch : $(STABLEHDRS)
 .PHONY: clean
 
 clean:
-    rm -f $(OBJS) $(APP) stable.pch
+    $(RM) $(OBJS) $(APP) stable.pch


### PR DESCRIPTION
'rm' is not a Windows command. It works in the CI but not in a usual
developer console.