### PR TITLE
 Fix recompile bug in direct mode when header changed

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -1010,8 +1010,13 @@ def processHeaderChangedMiss(stats, cache, outputFile, manifest, manifestHash, k
 
 def processNoManifestMiss(stats, cache, outputFile, manifestHash, baseDir, compiler, cmdLine, sourceFile):
     stats.registerSourceChangedMiss()
-    stripIncludes = '/showIncludes' not in cmdLine
-    returnCode, compilerOutput, compilerStderr = invokeRealCompiler(compiler, cmdLine, captureOutput=True)
+    if '/showIncludes' in cmdLine:
+        realCompilerCmdLine = cmdLine
+        stripIncludes = False
+    else:
+        realCompilerCmdLine = ['/showIncludes'] + cmdLine
+        stripIncludes = True
+    returnCode, compilerOutput, compilerStderr = invokeRealCompiler(compiler, realCompilerCmdLine, captureOutput=True)
     grabStderr = False
     # If these options present, cl.exe will list includes on stderr, not stdout
     for option in ['/E', '/EP', '/P']:

--- a/clcache.py
+++ b/clcache.py
@@ -1022,15 +1022,17 @@ def processNoManifestMiss(stats, cache, outputFile, manifestHash, baseDir, compi
         listOfIncludes, compilerStderr = parseIncludesList(compilerStderr, sourceFile, baseDir, stripIncludes)
     else:
         listOfIncludes, compilerOutput = parseIncludesList(compilerOutput, sourceFile, baseDir, stripIncludes)
-    manifest = Manifest(listOfIncludes, {})
-    listOfHeaderHashes = [getRelFileHash(fileName, baseDir) for fileName in listOfIncludes]
-    keyInManifest = ObjectCache.getKeyInManifest(listOfHeaderHashes)
-    cachekey = ObjectCache.getDirectCacheKey(manifestHash, keyInManifest)
 
     if returnCode == 0 and (outputFile == '' or os.path.exists(outputFile)):
+        # Store compile output and manifest
+        manifest = Manifest(listOfIncludes, {})
+        listOfHeaderHashes = [getRelFileHash(fileName, baseDir) for fileName in listOfIncludes]
+        keyInManifest = ObjectCache.getKeyInManifest(listOfHeaderHashes)
+        cachekey = ObjectCache.getDirectCacheKey(manifestHash, keyInManifest)
         addObjectToCache(stats, cache, outputFile, compilerOutput, compilerStderr, cachekey)
         manifest.hashes[keyInManifest] = cachekey
         cache.setManifest(manifestHash, manifest)
+
     stats.save()
     printTraceStatement("Finished. Exit code %d" % returnCode)
     return returnCode, compilerOutput, compilerStderr

--- a/tests.py
+++ b/tests.py
@@ -229,5 +229,27 @@ class TestHeaderChange(unittest.TestCase):
             output = subprocess.check_output(cmdRun).decode("ascii").strip()
             self.assertEqual(output, "2")
 
+    def testNoDirect(self):
+        with cd(os.path.join("tests", "header-change")):
+            self._clean()
+
+            with open("version.h", "w") as header:
+                header.write("#define VERSION 1")
+
+            self._compileAndLink(dict(os.environ, CLCACHE_NODIRECT="1"))
+            cmdRun = [os.path.abspath("main.exe")]
+            output = subprocess.check_output(cmdRun).decode("ascii").strip()
+            self.assertEqual(output, "1")
+
+            self._clean()
+
+            with open("version.h", "w") as header:
+                header.write("#define VERSION 2")
+
+            self._compileAndLink(dict(os.environ, CLCACHE_NODIRECT="1"))
+            cmdRun = [os.path.abspath("main.exe")]
+            output = subprocess.check_output(cmdRun).decode("ascii").strip()
+            self.assertEqual(output, "2")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -197,14 +197,16 @@ class TestPrecompiledHeaders(unittest.TestCase):
 class TestHeaderChange(unittest.TestCase):
     def testDirect(self):
         with cd(os.path.join("tests", "header-change")):
-            cmd_compile = [PYTHON_BINARY, CLCACHE_SCRIPT, "/nologo", "/EHsc", "main.cpp"]
+            cmd_compile = [PYTHON_BINARY, CLCACHE_SCRIPT, "/nologo", "/EHsc", "/c", "main.cpp"]
+            cmd_link = ["link", "/nologo", "/OUT:main.exe", "main.obj"]
 
             # Create header and compile
             with open("version.h", "w") as header:
                 header.write("#define VERSION 1")
             subprocess.check_call(cmd_compile)
 
-            # Run and check
+            # Link, run and check
+            subprocess.check_call(cmd_link)
             cmd_run = [os.path.abspath("main.exe")]
             output = subprocess.check_output(cmd_run).decode("ascii").strip()
             self.assertEqual(output, "1")
@@ -218,7 +220,8 @@ class TestHeaderChange(unittest.TestCase):
                 header.write("#define VERSION 2")
             subprocess.check_call(cmd_compile)
 
-            # Run and check
+            # Link, run and check
+            subprocess.check_call(cmd_link)
             cmd_run = [os.path.abspath("main.exe")]
             output = subprocess.check_output(cmd_run).decode("ascii").strip()
             self.assertEqual(output, "2")


### PR DESCRIPTION
This does not yet include a fix, but I am going to add one.

The issue is that `processNoManifestMiss()` does not add `/showIncludes` to a given command line, so `listOfIncludes` is always empty and thus the header content is never checked in direct mode.