### PR TITLE
Improve versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+clcache changelog
+=================
+
+## clcache 3.0.2 (2016-01-29)
+
+ * Python 3 compatibility
+ * Add new env variable to control clcache lock timeout
+ * Bugfix: Fix recompile bug in direct mode when header changed
+ * Bugfix: Fix compile error when clcache is used with precompiled headers
+ * Bugfix: `/MP[processMax]` was not properly parsed when `processMax` was unset
+ * Bugfix: Properly handle arguments including `\"` (e.g. `/Fo"Release\"`)
+ * Bugfix: Ensure the destination folder exists when copying object
+ * Bugfix: Fix crash when using CLCACHE_NODIRECT by restoring missing argument
+ * Bugfix: Fix fork-bomb when py2exe is used
+
+### Implementation details
+
+ * Setup CI system
+ * Add some basic tests

--- a/clcache.py
+++ b/clcache.py
@@ -478,6 +478,7 @@ def getCompilerHash(compilerBinary):
     data = '|'.join([
                 str(stat.st_mtime),
                 str(stat.st_size),
+                VERSION,
             ])
     hasher = HASH_ALGORITHM()
     hasher.update(data.encode("UTF-8"))

--- a/clcache.py
+++ b/clcache.py
@@ -51,6 +51,8 @@ import sys
 import multiprocessing
 import re
 
+VERSION = "3.0.2"
+
 HASH_ALGORITHM = hashlib.md5
 
 # Manifest file will have at most this number of hash lists in it. Need to avoi
@@ -1047,12 +1049,12 @@ def processNoManifestMiss(stats, cache, outputFile, manifestHash, baseDir, compi
 def main():
     if len(sys.argv) == 2 and sys.argv[1] == "--help":
         print("""\
-    clcache.py v3.0.2
+    clcache.py v{}
       --help   : show this help
       -s       : print cache statistics
       -z       : reset cache statistics
       -M <size>: set maximum cache size (in bytes)
-    """)
+    """.format(VERSION))
         return 0
 
     if len(sys.argv) == 2 and sys.argv[1] == "-s":

--- a/clcache.py
+++ b/clcache.py
@@ -51,7 +51,7 @@ import sys
 import multiprocessing
 import re
 
-VERSION = "3.0.2"
+VERSION = "3.0.3-dev"
 
 HASH_ALGORITHM = hashlib.md5
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 import py2exe
 
 setup(
-    version = "3.0.2",
+    version = "3.0.3-dev",
     description = "A compiler cache for Microsoft Visual Studio.",
     name = "CLCache",
     console = ["clcache.py"],


### PR DESCRIPTION
This makes clcache versioning clearer, adds a changelog and uses the clcache version as part of the compiler hash.