### PR TITLE
Fixed locking strategy to avoid corrupting cache stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ clcache changelog
 
  * Bugfix: Support use of py2exe with Python 3.4
  * Bugfix: Support includes parsing when cl language is not English (GH #65)
+ * Bugfix: Fix bug causing statistics to get corrupted after concurrent invocations
 
 ## clcache 3.0.2 (2016-01-29)
 

--- a/tests.py
+++ b/tests.py
@@ -231,9 +231,10 @@ class TestHits(BaseTest):
         cmd = [PYTHON_BINARY, CLCACHE_SCRIPT, "/nologo", "/EHsc", "/c", r'tests\hits-and-misses\hit.cpp']
         subprocess.check_call(cmd) # Ensure it has been compiled before
 
-        oldHits = clcache.getStatistics().numCacheHits()
+        cache = clcache.ObjectCache()
+        oldHits = clcache.CacheStatistics(cache).numCacheHits()
         subprocess.check_call(cmd) # This must hit now
-        newHits = clcache.getStatistics().numCacheHits()
+        newHits = clcache.CacheStatistics(cache).numCacheHits()
         self.assertEqual(newHits, oldHits + 1)
 
 class TestPrecompiledHeaders(BaseTest):


### PR DESCRIPTION
Concurrent invocations of clcache.py would easily break the cache
statistics. The reason for this was that in some cases, a
read/modify/write session on the statistics was not guarded by a single
lock, so two clcache.py processes A and B which try to bump some value
(e.g. number of cache entries)might have executed a sequence like

  A read value 5
  B read value 5
  A write value 6
  B write value 6

Fix this by rewriting the locking strategy. Locking is no longer done at
the lowest level (since such locks do not compose) but at the toplevel
in all relevant areas:

- When printing the cache statistics
- When resetting the cache statistics
- When changing the cache configuration

Furthermore, when processing a compiler request, the lock is acquired at
least once in order to:

- Check if the invocation can be cached at all
- Check if there is a cache entry

Then (without the lock being held!) the compiler is invoked. Finally,
depending on the invocation and the configuration settings, a
post-processing function is invoked to update the bookkeeping. This
function also takes care of holding the lock as needed.