### PR TITLE
Parsing multiline options file

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -581,7 +581,7 @@ def extractArgument(argument):
     return argument.strip()
 
 
-def splitCommandsFile(line):
+def splitCommandsLine(line):
     # Note, we must treat lines in quotes as one argument. We do not use shlex
     # since seems it difficult to set up it to correctly parse escaped quotes.
     # A good test line to split is
@@ -605,6 +605,12 @@ def splitCommandsFile(line):
         result.append(extractArgument(line[wordStart:]))
     return result
 
+def splitCommandsFile(content):
+    ret = []
+    for line in content.splitlines(True):
+        ret.extend(splitCommandsLine(line.strip()))
+
+    return ret
 
 def expandCommandLine(cmdline):
     ret = []

--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,11 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest(r'"-DWEBRTC_SVNREVISION=\"Unavailable(issue687)\"" -D_WIN32_WINNT=0x0602',
                           [r'-DWEBRTC_SVNREVISION=\"Unavailable(issue687)\"', '-D_WIN32_WINNT=0x0602'])
 
+    def testLineEndings(self):
+        self._genericTest('-A\n-B', ['-A', '-B'])
+        self._genericTest('-A\r\n-B', ['-A', '-B'])
+        self._genericTest('-A -B\r\n-C -D -E', ['-A', '-B', '-C', '-D', '-E'])
+
 class TestParseIncludes(BaseTest):
     def _readSampleFileDefault(self, lang=None):
         if lang == "de":


### PR DESCRIPTION
This PR adds support for cl options file with multiple lines.
Usually these files generated by gradle.

Separation of #85.