### PR TITLE
robust cache handling

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -163,6 +163,9 @@ class ObjectCache:
         objectInfos = [(os.stat(fn), fn) for fn in objects]
         objectInfos.sort(key=lambda t: t[0].st_atime)
 
+        # compute real current size to fix up the stored cacheSize
+        currentSize = sum(x[0].st_size for x in objectInfos)
+
         for stat, fn in objectInfos:
             rmtree(os.path.split(fn)[0])
             currentSize -= stat.st_size

--- a/clcache.py
+++ b/clcache.py
@@ -166,17 +166,22 @@ class ObjectCache:
         # compute real current size to fix up the stored cacheSize
         currentSize = sum(x[0].st_size for x in objectInfos)
 
+        removedItems = 0
         for stat, fn in objectInfos:
             rmtree(os.path.split(fn)[0])
+            removedItems += 1
             currentSize -= stat.st_size
             if currentSize < effectiveMaximumSize:
                 break
 
         stats.setCacheSize(currentSize)
+        stats.setNumCacheEntries(len(objectInfos) - removedItems)
+
 
     def removeObjects(self, stats, removedObjects):
         if len(removedObjects) == 0:
             return
+
         currentSize = stats.currentCacheSize()
         for o in removedObjects:
             dirPath = self._cacheEntryDir(o)
@@ -188,8 +193,8 @@ class ObjectCache:
                 # output (for preprocess-only).
                 fileStat = os.stat(objectPath)
                 currentSize -= fileStat.st_size
+                stats.unregisterCacheEntry(fileStat.st_size)
             rmtree(dirPath)
-        stats.setCacheSize(currentSize)
 
     @staticmethod
     def getManifestHash(compilerBinary, commandLine, sourceFile):
@@ -436,9 +441,16 @@ class CacheStatistics:
     def numCacheEntries(self):
         return self._stats["CacheEntries"]
 
+    def setNumCacheEntries(self, number):
+        self._stats["CacheEntries"] = number
+
     def registerCacheEntry(self, size):
         self._stats["CacheEntries"] += 1
         self._stats["CacheSize"] += size
+
+    def unregisterCacheEntry(self, size):
+        self._stats["CacheEntries"] -= 1
+        self._stats["CacheSize"] -= size
 
     def currentCacheSize(self):
         return self._stats["CacheSize"]


### PR DESCRIPTION
the current implementation completely relies on the correct entries of the stats file. that might not reflect the real-world e.g. if parts of the cache were deleted manually by a user.

the cache also does not correctly reflect the number of entries as removing objects from the cache won't update the stats