### PR TITLE
Fix variable name in LogicException.__init__

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -78,7 +78,7 @@ class ObjectCacheLockException(Exception):
 
 class LogicException(Exception):
     def __init__(self, message):
-        self.value = message
+        self.message = message
 
     def __str__(self):
         return repr(self.message)


### PR DESCRIPTION
This was probably copy/pasted from different python examples. The member that holds the exception text should be called `self.message`.