### PR TITLE
Added initial test for clearing the cache

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -171,7 +171,7 @@ class ObjectCache:
         objectInfos = []
         for o in objects:
             try:
-                objectInfos.append((os.stat(fn), fn))
+                objectInfos.append((os.stat(o), o))
             except WindowsError:
                 pass
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -245,5 +245,54 @@ class TestRunParallel(BaseTest):
             self.assertEqual(hits + misses, 20)
 
 
+class TestClearing(BaseTest):
+    def _clearCache(self):
+        subprocess.check_call([PYTHON_BINARY, CLCACHE_SCRIPT, "-C"])
+
+    def testClearIdempotency(self):
+        cache = clcache.ObjectCache()
+
+        self._clearCache()
+        stats = clcache.CacheStatistics(cache)
+        self.assertEqual(stats.currentCacheSize(), 0)
+        self.assertEqual(stats.numCacheEntries(), 0)
+
+        # Clearing should be idempotent
+        self._clearCache()
+        stats = clcache.CacheStatistics(cache)
+        self.assertEqual(stats.currentCacheSize(), 0)
+        self.assertEqual(stats.numCacheEntries(), 0)
+
+    def testClearPostcondition(self):
+        cache = clcache.ObjectCache()
+
+        # Compile a random file to populate cache
+        cmd = [PYTHON_BINARY, CLCACHE_SCRIPT, "/nologo", "/EHsc", "/c", "tests\\fibonacci.cpp"]
+        subprocess.check_call(cmd)
+
+        # Now there should be something in the cache
+        stats = clcache.CacheStatistics(cache)
+        self.assertTrue(stats.currentCacheSize() > 0)
+        self.assertTrue(stats.numCacheEntries() > 0)
+
+        # Now, clear the cache: the stats should remain unchanged except for
+        # the cache size and number of cache entries.
+        self._clearCache()
+        oldStats = stats
+        stats = clcache.CacheStatistics(cache)
+        self.assertEqual(stats.currentCacheSize(), 0)
+        self.assertEqual(stats.numCacheEntries(), 0)
+        self.assertEqual(stats.numCallsWithoutSourceFile(), oldStats.numCallsWithoutSourceFile())
+        self.assertEqual(stats.numCallsWithMultipleSourceFiles(), oldStats.numCallsWithMultipleSourceFiles())
+        self.assertEqual(stats.numCallsWithPch(), oldStats.numCallsWithPch())
+        self.assertEqual(stats.numCallsForLinking(), oldStats.numCallsForLinking())
+        self.assertEqual(stats.numCallsForExternalDebugInfo(), oldStats.numCallsForExternalDebugInfo())
+        self.assertEqual(stats.numEvictedMisses(), oldStats.numEvictedMisses())
+        self.assertEqual(stats.numHeaderChangedMisses(), oldStats.numHeaderChangedMisses())
+        self.assertEqual(stats.numSourceChangedMisses(), oldStats.numSourceChangedMisses())
+        self.assertEqual(stats.numCacheHits(), oldStats.numCacheHits())
+        self.assertEqual(stats.numCacheMisses(), oldStats.numCacheMisses())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As an initial test, verify that cleaning the cache is idempotent, i.e.
repeatedly cleaning the cache should work and maintain the same
postcondition.