### PR TITLE
More splitCommandsFile()

### DIFF
--- a/unittests.py
+++ b/unittests.py
@@ -76,6 +76,16 @@ class TestSplitCommandsFile(BaseTest):
     def testEmpty(self):
         self._genericTest('', [])
 
+    def testSimple(self):
+        self._genericTest('/nologo', ['/nologo'])
+        self._genericTest('/nologo /c', ['/nologo', '/c'])
+        self._genericTest('/nologo /c -I.', ['/nologo', '/c', '-I.'])
+
+    def testWhitespace(self):
+        self._genericTest('-A -B    -C', ['-A', '-B', '-C'])
+        self._genericTest('   -A -B -C', ['-A', '-B', '-C'])
+        self._genericTest('-A -B -C   ', ['-A', '-B', '-C'])
+
     def testVyachselavCase(self):
         self._genericTest(
             r'"-IC:\Program files\Some library" -DX=1 -DVERSION=\"1.0\" -I..\.. -I"..\..\lib" -DMYPATH=\"C:\Path\"',

--- a/unittests.py
+++ b/unittests.py
@@ -70,14 +70,15 @@ class TestExtractArgument(BaseTest):
 
 
 class TestSplitCommandsFile(BaseTest):
+    def _genericTest(self, commandLine, expected):
+        self.assertEqual(clcache.splitCommandsFile(commandLine), expected)
+
     def testEmpty(self):
-        self.assertEqual(clcache.splitCommandsFile(''), [])
+        self._genericTest('', [])
 
     def testVyachselavCase(self):
-        commandsFile = \
-            r'"-IC:\Program files\Some library" -DX=1 -DVERSION=\"1.0\" -I..\.. -I"..\..\lib" -DMYPATH=\"C:\Path\"'
-        self.assertEqual(
-            clcache.splitCommandsFile(commandsFile),
+        self._genericTest(
+            r'"-IC:\Program files\Some library" -DX=1 -DVERSION=\"1.0\" -I..\.. -I"..\..\lib" -DMYPATH=\"C:\Path\"',
             [
                 r'-IC:\Program files\Some library',
                 r'-DX=1',
@@ -88,15 +89,9 @@ class TestSplitCommandsFile(BaseTest):
             ])
 
     def testLineEndings(self):
-        self.assertEqual(
-            clcache.splitCommandsFile('-A\n-B'),
-            ['-A', '-B'])
-        self.assertEqual(
-            clcache.splitCommandsFile('-A\r\n-B'),
-            ['-A', '-B'])
-        self.assertEqual(
-            clcache.splitCommandsFile('-A -B\r\n-C -D -E'),
-            ['-A', '-B', '-C', '-D', '-E'])
+        self._genericTest('-A\n-B', ['-A', '-B'])
+        self._genericTest('-A\r\n-B', ['-A', '-B'])
+        self._genericTest('-A -B\r\n-C -D -E', ['-A', '-B', '-C', '-D', '-E'])
 
 
 class TestMultipleSourceFiles(BaseTest):


### PR DESCRIPTION
This introduces a generic test method for TestSplitCommandsFile and adds some simple tests.

This is done because it is likely that the methods might need changes, so it is important that current functionality will not break.