### PR TITLE
Add microsoft command line parsing examples as test

### DIFF
--- a/unittests.py
+++ b/unittests.py
@@ -88,6 +88,13 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest('   -A -B -C', ['-A', '-B', '-C'])
         self._genericTest('-A -B -C   ', ['-A', '-B', '-C'])
 
+    def testMicrosoftExamples(self):
+        # https://msdn.microsoft.com/en-us/library/17w5ykft.aspx
+        self._genericTest(r'"abc" d e', ['abc', 'd', 'e'])
+        self._genericTest(r'a\\b d"e f"g h', [r'a\\b', 'de fg', 'h'])
+        self._genericTest(r'a\\\"b c d', [r'a\"b', 'c', 'd'])
+        self._genericTest(r'a\\\\"b c" d e', [r'a\\b c', 'd', 'e'])
+
     def testQuotesAroundArgument(self):
         self._genericTest(r'/Fo"C:\out dir\main.obj"', [r'/Fo"C:\out dir\main.obj"'])
         self._genericTest(r'/c /Fo"C:\out dir\main.obj"', ['/c', r'/Fo"C:\out dir\main.obj"'])


### PR DESCRIPTION
A lot of tests right do not follow the Microsoft way of [Parsing C++ Command-Line Arguments](https://msdn.microsoft.com/en-us/library/17w5ykft.aspx).

Before trying to fix all of those, I think we should concentrate on making the tests from the Microsoft documentation work. Those are very simple cases that look like they cover all of the given rules.

If you, @frerich want to test your tokenizer, feel free to cherry-pick or copy this test and integrate it in your work.