### PR TITLE
Drop ad-hoc response file parsing in favor of structured LLVM-based tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ clcache changelog
  * Improvement: better protection against storing corrupt objects in the cache
    in case clcache is terminated in the middle of storing a new cache entry.
  * Bugfix: Command files with multiple lines are now handled correctly.
+ * Bugfix: Command files which contribute arguments ending in a backslash are
+   now parsed correctly (GH #108).
  * Bugfix: Properly handle non-ASCII compiler output (GH #64)
 
 ## clcache 3.1.0 (2016-06-09)

--- a/clcache.py
+++ b/clcache.py
@@ -614,21 +614,6 @@ def printTraceStatement(msg):
         print(os.path.join(scriptDir, "clcache.py") + " " + msg)
 
 
-def extractArgument(argument):
-    # If there are quotes from both sides of argument, remove them
-    # "-Isome path" must becomse -Isome path
-    if not argument:
-        return ""
-
-    if argument == '"':
-        raise Exception("Invalid argument: '\"'")
-
-    if argument[0] == '"' and argument[-1] == '"':
-        argument = argument[1:-1] # Cut first and last character
-
-    return argument.strip()
-
-
 class CommandLineTokenizer(object):
     def __init__(self, content):
         self.argv = []
@@ -704,8 +689,7 @@ class CommandLineTokenizer(object):
 
 
 def splitCommandsFile(content):
-    tokenizer = CommandLineTokenizer(content)
-    return [extractArgument(arg) for arg in tokenizer.argv]
+    return CommandLineTokenizer(content).argv
 
 
 def expandCommandLine(cmdline):

--- a/clcache.py
+++ b/clcache.py
@@ -34,6 +34,7 @@ from __future__ import print_function
 # All string literals are unicode strings. Requires Python 3.3+
 # (http://python-future.org/faq.html#which-versions-of-python-does-python-future-support)
 from __future__ import unicode_literals
+from __future__ import division
 
 from ctypes import windll, wintypes
 import codecs
@@ -692,7 +693,7 @@ class CommandLineTokenizer(object):
 
         followedByDoubleQuote = self._pos < len(self._content) and self._content[self._pos] == '"'
         if followedByDoubleQuote:
-            self._token += '\\' * (numBackslashes / 2)
+            self._token += '\\' * (numBackslashes // 2)
             if numBackslashes % 2 == 0:
                 self._pos -= 1
             else:

--- a/unittests.py
+++ b/unittests.py
@@ -88,6 +88,13 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest('   -A -B -C', ['-A', '-B', '-C'])
         self._genericTest('-A -B -C   ', ['-A', '-B', '-C'])
 
+    def testMicrosoftExamples(self):
+        # https://msdn.microsoft.com/en-us/library/17w5ykft.aspx
+        self._genericTest(r'"abc" d e', ['abc', 'd', 'e'])
+        self._genericTest(r'a\\b d"e f"g h', [r'a\\b', 'de fg', 'h'])
+        self._genericTest(r'a\\\"b c d', [r'a\"b', 'c', 'd'])
+        self._genericTest(r'a\\\\"b c" d e', [r'a\\b c', 'd', 'e'])
+
     def testQuotesAroundArgument(self):
         self._genericTest(r'/Fo"C:\out dir\main.obj"', [r'/Fo"C:\out dir\main.obj"'])
         self._genericTest(r'/c /Fo"C:\out dir\main.obj"', ['/c', r'/Fo"C:\out dir\main.obj"'])

--- a/unittests.py
+++ b/unittests.py
@@ -108,10 +108,17 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest(r'/c "/Fo"something\main.obj"" /nologo', ['/c', r'/Fosomething\main.obj', '/nologo'])
 
     def testBackslashBeforeQuote(self):
+        # Pathological cases of escaping the quote incorrectly.
         self._genericTest(r'/Fo"C:\out dir\"', [r'/FoC:\out dir"'])
         self._genericTest(r'/c /Fo"C:\out dir\"', ['/c', r'/FoC:\out dir"'])
         self._genericTest(r'/Fo"C:\out dir\" /nologo', [r'/FoC:\out dir" /nologo'])
         self._genericTest(r'/c /Fo"C:\out dir\" /nologo', ['/c', r'/FoC:\out dir" /nologo'])
+
+        # Sane cases of escaping the backslash correctly.
+        self._genericTest(r'/Fo"C:\out dir\\"', [r'/FoC:\out dir' '\\'])
+        self._genericTest(r'/c /Fo"C:\out dir\\"', ['/c', r'/FoC:\out dir' '\\'])
+        self._genericTest(r'/Fo"C:\out dir\\" /nologo', [r'/FoC:\out dir' '\\', r'/nologo'])
+        self._genericTest(r'/c /Fo"C:\out dir\\" /nologo', ['/c', r'/FoC:\out dir' '\\', r'/nologo'])
 
     def testVyachselavCase(self):
         self._genericTest(

--- a/unittests.py
+++ b/unittests.py
@@ -47,30 +47,6 @@ class BaseTest(unittest.TestCase):
         super(BaseTest, self).__init__(*args, **kwargs)
 
 
-class TestExtractArgument(BaseTest):
-    def testSimple(self):
-        # Keep
-        self.assertEqual(clcache.extractArgument(r''), r'')
-        self.assertEqual(clcache.extractArgument(r'1'), r'1')
-        self.assertEqual(clcache.extractArgument(r'myfile.cpp'), r'myfile.cpp')
-        self.assertEqual(
-            clcache.extractArgument(r'/DEXTERNAL_DLL=__declspec(dllexport)'),
-            r'/DEXTERNAL_DLL=__declspec(dllexport)')
-        self.assertEqual(clcache.extractArgument(r'-DVERSION=\\"1.0\\"'), r'-DVERSION=\\"1.0\\"')
-        self.assertEqual(clcache.extractArgument(r'-I"..\.."'), r'-I"..\.."')
-
-        # Extract
-        self.assertEqual(
-            clcache.extractArgument(r'"-IC:\Program Files\Lib1"'),
-            r'-IC:\Program Files\Lib1')
-        self.assertEqual(
-            clcache.extractArgument(r'"/Fo"CrashReport.dir\Release\""'),
-            r'/Fo"CrashReport.dir\Release\"')
-        self.assertEqual(
-            clcache.extractArgument(r'"-DWEBRTC_SVNREVISION=\"Unavailable(issue687)\""'),
-            r'-DWEBRTC_SVNREVISION=\"Unavailable(issue687)\"')
-
-
 class TestSplitCommandsFile(BaseTest):
     def _genericTest(self, commandLine, expected):
         self.assertEqual(clcache.splitCommandsFile(commandLine), expected)

--- a/unittests.py
+++ b/unittests.py
@@ -108,10 +108,10 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest(r'/c "/Fo"something\main.obj"" /nologo', ['/c', r'/Fosomething\main.obj', '/nologo'])
 
     def testBackslashBeforeQuote(self):
-        self._genericTest(r'/Fo"C:\out dir\"', [r'/Fo"C:\out dir\"'])
-        self._genericTest(r'/c /Fo"C:\out dir\"', ['/c', r'/Fo"C:\out dir\"'])
-        self._genericTest(r'/Fo"C:\out dir\" /nologo', [r'/Fo"C:\out dir\"', '/nologo'])
-        self._genericTest(r'/c /Fo"C:\out dir\" /nologo', ['/c', r'/Fo"C:\out dir\"', '/nologo'])
+        self._genericTest(r'/Fo"C:\out dir\"', [r'/FoC:\out dir"'])
+        self._genericTest(r'/c /Fo"C:\out dir\"', ['/c', r'/FoC:\out dir"'])
+        self._genericTest(r'/Fo"C:\out dir\" /nologo', [r'/FoC:\out dir" /nologo'])
+        self._genericTest(r'/c /Fo"C:\out dir\" /nologo', ['/c', r'/FoC:\out dir" /nologo'])
 
     def testVyachselavCase(self):
         self._genericTest(
@@ -119,10 +119,10 @@ class TestSplitCommandsFile(BaseTest):
             [
                 r'-IC:\Program files\Some library',
                 r'-DX=1',
-                r'-DVERSION=\"1.0\"',
+                r'-DVERSION="1.0"',
                 r'-I..\..',
-                r'-I"..\..\lib"',
-                r'-DMYPATH=\"C:\Path\"'
+                r'-I..\..\lib',
+                r'-DMYPATH="C:\Path"'
             ])
 
     def testLineEndings(self):

--- a/unittests.py
+++ b/unittests.py
@@ -96,16 +96,16 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest(r'a\\\\"b c" d e', [r'a\\b c', 'd', 'e'])
 
     def testQuotesAroundArgument(self):
-        self._genericTest(r'/Fo"C:\out dir\main.obj"', [r'/Fo"C:\out dir\main.obj"'])
-        self._genericTest(r'/c /Fo"C:\out dir\main.obj"', ['/c', r'/Fo"C:\out dir\main.obj"'])
-        self._genericTest(r'/Fo"C:\out dir\main.obj" /nologo', [r'/Fo"C:\out dir\main.obj"', '/nologo'])
-        self._genericTest(r'/c /Fo"C:\out dir\main.obj" /nologo', ['/c', r'/Fo"C:\out dir\main.obj"', '/nologo'])
+        self._genericTest(r'/Fo"C:\out dir\main.obj"', [r'/FoC:\out dir\main.obj'])
+        self._genericTest(r'/c /Fo"C:\out dir\main.obj"', ['/c', r'/FoC:\out dir\main.obj'])
+        self._genericTest(r'/Fo"C:\out dir\main.obj" /nologo', [r'/FoC:\out dir\main.obj', '/nologo'])
+        self._genericTest(r'/c /Fo"C:\out dir\main.obj" /nologo', ['/c', r'/FoC:\out dir\main.obj', '/nologo'])
 
     def testDoubleQuoted(self):
-        self._genericTest(r'"/Fo"something\main.obj""', [r'/Fo"something\main.obj"'])
-        self._genericTest(r'/c "/Fo"something\main.obj""', ['/c', r'/Fo"something\main.obj"'])
-        self._genericTest(r'"/Fo"something\main.obj"" /nologo', [r'/Fo"something\main.obj"', '/nologo'])
-        self._genericTest(r'/c "/Fo"something\main.obj"" /nologo', ['/c', r'/Fo"something\main.obj"', '/nologo'])
+        self._genericTest(r'"/Fo"something\main.obj""', [r'/Fosomething\main.obj'])
+        self._genericTest(r'/c "/Fo"something\main.obj""', ['/c', r'/Fosomething\main.obj'])
+        self._genericTest(r'"/Fo"something\main.obj"" /nologo', [r'/Fosomething\main.obj', '/nologo'])
+        self._genericTest(r'/c "/Fo"something\main.obj"" /nologo', ['/c', r'/Fosomething\main.obj', '/nologo'])
 
     def testBackslashBeforeQuote(self):
         self._genericTest(r'/Fo"C:\out dir\"', [r'/Fo"C:\out dir\"'])


### PR DESCRIPTION
Over the last couple of years, there have been numerous bug reports
about how clcache fails to parse response files correctly. This was
always handled in a somewhat ad-hoc manner: we tried to patch the code
such that the newly discovered case works, without breaking the old
ones.

Being dissatisfied with this situation, I looked at how other projects
parse response files and became aware of some code in the LLVM project
solving this exact issue.

The new 'CommandLineTokenizer' class introduced by this patch is a port
of the LLVM function 'cl::TokenizeWindowsCommandLine', slightly
exploiting the fact that functions in Python are nicer first class
citizens (so a 'state' variable is not needed).

This fixes #108 .