### PR TITLE
Mention how to integrate clcache with Visual Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ clcache changelog
 
  * Improvement: better protection against storing corrupt objects in the cache
    in case clcache is terminated in the middle of storing a new cache entry.
+ * Improvement: The README now explains an approach to making Visual Studio
+   pick up clcache.
  * Bugfix: Command files with multiple lines are now handled correctly.
  * Bugfix: Properly handle non-ASCII compiler output (GH #64)
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -36,6 +36,17 @@ renamed and forward all the arguments to the real compiler executable.
 This way, simply running 'cl' will invoke the script instead of the real
 compiler.
 
+Installation For Visual Studio
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some users have reported (see e.g. GitHub issue #18) that in order to make Visual Studio pick up `clcache`, the original compiler binary needs to be moved out of the
+way and replaced with the executable generated via the `py2exe` script:
+
+1. Rename `cl.exe` to e.g. `cl_original.exe`
+2. Rename `cl.exe.config` to e.g. `cl_original.exe.config`
+3. Copy `clcache.exe` to `cl.exe`
+4. Set `CLCACHE_CL` environment variable to point to `cl_original.exe`.
+
 Options
 ~~~~~~~
 


### PR DESCRIPTION
It's apparently not too easy to make Visual Studio pick up clcache. I
don't use the IDE myself, but others described that replacing the
original binary works. So let's at least mention this approach.

Resolves #18.