### PR TITLE
Don't claim that you can specify only one source file

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -109,7 +109,6 @@ line must be true:
 * The +/link+ switch must not be present
 * The +/c+ switch must be present
 * The +/Zi+ switch must not be present (+/Z7+ is okay though)
-* There must be exactly one source file present on the command line.
 
 If all the above requirements are met, clcache forwards the call to the
 preprocessor by replacing +/c+ with +/EP+ in the command line and then


### PR DESCRIPTION
Commit c8bc1ec6f5f87111f465648a59d3100afdb3194e did away with that
restriction (at least to a large degree).

This resolves a concern raised in GitHub issue #32.