### PR TITLE
Add a lot of /Fo testing

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -814,13 +814,13 @@ class CommandLineAnalyzer(object):
         outputFile = None
         if 'Fo' in options:
             outputFile = options['Fo'][0]
+            outputFile = os.path.normpath(outputFile)
 
             if os.path.isdir(outputFile):
                 srcFileName = os.path.basename(sourceFiles[0])
                 outputFile = os.path.join(outputFile,
                                           os.path.splitext(srcFileName)[0] + ".obj")
-            else:
-                outputFile = os.path.normpath(outputFile)
+
         elif preprocessing:
             if 'P' in options:
                 # Preprocess to file.

--- a/unittests.py
+++ b/unittests.py
@@ -33,12 +33,24 @@
 #
 # In Python unittests are always members, not functions. Silence lint in this file.
 # pylint: disable=no-self-use
+from contextlib import contextmanager
 import multiprocessing
+import os
 import unittest
 
 import clcache
 from clcache import AnalysisResult
 from clcache import CommandLineAnalyzer
+
+
+@contextmanager
+def cd(targetDirectory):
+    oldDirectory = os.getcwd()
+    os.chdir(os.path.expanduser(targetDirectory))
+    try:
+        yield
+    finally:
+        os.chdir(oldDirectory)
 
 
 class BaseTest(unittest.TestCase):
@@ -156,7 +168,10 @@ class TestAnalyzeCommandLine(BaseTest):
         self._testFo('/FoThe Out File.obj', 'The Out File.obj')
 
         # Existing directory
-        self._testFo('/Fo.', r'.\main.obj')
+        with cd(os.path.join("tests", "unittests")):
+            self._testFo(r'/Fo.', r'.\main.obj')
+            self._testFo(r'/Fofo-build-debug', r'fo-build-debug\main.obj')
+            self._testFo(r'/Fofo-build-debug\\', r'fo-build-debug\main.obj')
 
     def testOutputFileNormalizePath(self):
         # Out dir does not exist, but preserve path. Compiler will complain

--- a/unittests.py
+++ b/unittests.py
@@ -152,6 +152,9 @@ class TestAnalyzeCommandLine(BaseTest):
         # Given object filename (custom extension .dat)
         self._testFo('/FoTheOutFile.dat', 'TheOutFile.dat')
 
+        # Given object filename (with spaces)
+        self._testFo('/FoThe Out File.obj', 'The Out File.obj')
+
         # Existing directory
         self._testFo('/Fo.', r'.\main.obj')
 

--- a/unittests.py
+++ b/unittests.py
@@ -125,6 +125,10 @@ class TestAnalyzeCommandLine(BaseTest):
         self.assertEqual(sourceFile, expectedSourceFile)
         self.assertEqual(outputFile, expectedOutputFile)
 
+    def _testFo(self, foArgument, expectedObjectFilepath):
+        self._testFull(['/c', foArgument, 'main.cpp'],
+                       AnalysisResult.Ok, "main.cpp", expectedObjectFilepath)
+
     def testEmpty(self):
         self._testShort([], AnalysisResult.NoSourceFile)
 
@@ -136,41 +140,34 @@ class TestAnalyzeCommandLine(BaseTest):
         self._testShort(['/c', '/nologo'], AnalysisResult.NoSourceFile)
         self._testShort(['/c', '/nologo', '/Zi'], AnalysisResult.NoSourceFile)
 
-    def testOutputFile(self):
-        # Given object filename (default extension .obj)
-        self._testFull(['/c', '/FoTheOutFile.obj', 'main.cpp'],
-                       AnalysisResult.Ok, "main.cpp", 'TheOutFile.obj')
-
-        # Given object filename (custom extension .dat)
-        self._testFull(['/c', '/FoTheOutFile.dat', 'main.cpp'],
-                       AnalysisResult.Ok, "main.cpp", 'TheOutFile.dat')
-
+    def testOutputFileFromSourcefile(self):
         # Generate from .cpp filename
         self._testFull(['/c', 'main.cpp'],
                        AnalysisResult.Ok, 'main.cpp', 'main.obj')
 
+    def testOutputFile(self):
+        # Given object filename (default extension .obj)
+        self._testFo('/FoTheOutFile.obj', 'TheOutFile.obj')
+
+        # Given object filename (custom extension .dat)
+        self._testFo('/FoTheOutFile.dat', 'TheOutFile.dat')
+
         # Existing directory
-        self._testFull(['/c', '/Fo.', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', r'.\main.obj')
+        self._testFo('/Fo.', r'.\main.obj')
 
     def testOutputFileNormalizePath(self):
         # Out dir does not exist, but preserve path. Compiler will complain
-        self._testFull(['/c', r'/FoDebug\TheOutFile.obj', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', r'Debug\TheOutFile.obj')
+        self._testFo(r'/FoDebug\TheOutFile.obj', r'Debug\TheOutFile.obj')
 
         # Convert to Windows path separatores (like cl does too)
-        self._testFull(['/c', r'/FoDebug/TheOutFile.obj', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', r'Debug\TheOutFile.obj')
+        self._testFo(r'/FoDebug/TheOutFile.obj', r'Debug\TheOutFile.obj')
 
         # Different separators work as well
-        self._testFull(['/c', r'/FoDe\bug/TheOutFile.obj', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', r'De\bug\TheOutFile.obj')
+        self._testFo(r'/FoDe\bug/TheOutFile.obj', r'De\bug\TheOutFile.obj')
 
         # Double slash
-        self._testFull(['/c', r'/FoDebug//TheOutFile.obj', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', r'Debug\TheOutFile.obj')
-        self._testFull(['/c', r'/FoDebug\\TheOutFile.obj', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', r'Debug\TheOutFile.obj')
+        self._testFo(r'/FoDebug//TheOutFile.obj', r'Debug\TheOutFile.obj')
+        self._testFo(r'/FoDebug\\TheOutFile.obj', r'Debug\TheOutFile.obj')
 
     def testLink(self):
         self._testShort(["main.cpp"], AnalysisResult.CalledForLink)


### PR DESCRIPTION
This adds most tests from my previous PR but respects the current state of command line splitting.

I removed all implementation changes for now to check if those are still needed. I guess some normalization of the `outputFile`  will be necessary.

~~I cherry-picked, #125 assuming it will be on master soon. Then I'll remove it from my branch.~~