### PR TITLE
Use relative path to preprocess output file (.i file) when generated from source file

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -831,7 +831,7 @@ class CommandLineAnalyzer(object):
                 if 'Fi' in options:
                     outputFile = options['Fi'][0]
                 else:
-                    outputFile = os.path.join(os.getcwd(), basenameWithoutExtension(sourceFiles[0]) + ".i")
+                    outputFile = basenameWithoutExtension(sourceFiles[0]) + ".i"
             else:
                 # Preprocess to stdout. Use empty string rather then None to ease
                 # output to log.

--- a/unittests.py
+++ b/unittests.py
@@ -173,9 +173,12 @@ class TestAnalyzeCommandLine(BaseTest):
         self._testShort(['/c', '/nologo', '/Zi'], AnalysisResult.NoSourceFile)
 
     def testOutputFileFromSourcefile(self):
-        # Generate from .cpp filename
+        # For object file
         self._testFull(['/c', 'main.cpp'],
                        AnalysisResult.Ok, 'main.cpp', 'main.obj')
+        # For preprocessor file
+        self._testFull(['/c', '/P', 'main.cpp'],
+                       AnalysisResult.Ok, 'main.cpp', 'main.i')
 
     def testOutputFile(self):
         # Given object filename (default extension .obj)


### PR DESCRIPTION
relative files in outputFile are supported and well tested.

This simplifies code and testing but does not fix a bug.

Actually it is one step before fixing a real bug (`/Fo` must be ignored when preprocessing is used). Follow-up tests are about to come.