### PR TITLE
Make local variable `sourceFiles` plural; let analyze() return list

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -852,7 +852,7 @@ class CommandLineAnalyzer(object):
             outputFile = CommandLineAnalyzer._outputFileFromArgument(options, 'Fo', sourceFiles[0], '.obj')
 
         printTraceStatement("Compiler output file: {}".format(outputFile))
-        return AnalysisResult.Ok, sourceFiles[0], outputFile
+        return AnalysisResult.Ok, sourceFiles, outputFile
 
 
 def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False):
@@ -1249,10 +1249,10 @@ def processCompileRequest(cache, compiler, args):
 
     cmdLine = expandCommandLine(sys.argv[1:])
     printTraceStatement("Expanded commandline '%s'" % cmdLine)
-    analysisResult, sourceFile, outputFile = CommandLineAnalyzer.analyze(cmdLine)
+    analysisResult, sourceFiles, outputFile = CommandLineAnalyzer.analyze(cmdLine)
 
     if analysisResult == AnalysisResult.MultipleSourceFilesSimple:
-        return reinvokePerSourceFile(cmdLine, sourceFile), '', ''
+        return reinvokePerSourceFile(cmdLine, sourceFiles), '', ''
 
     if analysisResult != AnalysisResult.Ok:
         with cache.lock:
@@ -1280,7 +1280,7 @@ def processCompileRequest(cache, compiler, args):
     if 'CLCACHE_NODIRECT' in os.environ:
         return processNoDirect(cache, outputFile, compiler, cmdLine)
     else:
-        return processDirect(cache, outputFile, compiler, cmdLine, sourceFile)
+        return processDirect(cache, outputFile, compiler, cmdLine, sourceFiles[0])
 
 
 def processDirect(cache, outputFile, compiler, cmdLine, sourceFile):

--- a/clcache.py
+++ b/clcache.py
@@ -516,9 +516,9 @@ class CacheStatistics(object):
 
 
 class AnalysisResult(object):
-    Ok, NoSourceFile, MultipleSourceFilesSimple, \
+    Ok, NoSourceFile, \
         MultipleSourceFilesComplex, CalledForLink, \
-        CalledWithPch, ExternalDebugInfo = list(range(7))
+        CalledWithPch, ExternalDebugInfo = list(range(6))
 
 
 def getCompilerHash(compilerBinary):
@@ -841,7 +841,7 @@ class CommandLineAnalyzer(object):
         if len(sourceFiles) > 1:
             if compl:
                 return AnalysisResult.MultipleSourceFilesComplex, None, None
-            return AnalysisResult.MultipleSourceFilesSimple, sourceFiles, None
+            return AnalysisResult.Ok, sourceFiles, None
 
         if preprocessing:
             if CommandLineAnalyzer._preprocessToStdout(options):
@@ -1251,10 +1251,15 @@ def processCompileRequest(cache, compiler, args):
     printTraceStatement("Expanded commandline '%s'" % cmdLine)
     analysisResult, sourceFiles, outputFile = CommandLineAnalyzer.analyze(cmdLine)
 
-    if analysisResult == AnalysisResult.MultipleSourceFilesSimple:
-        return reinvokePerSourceFile(cmdLine, sourceFiles), '', ''
-
-    if analysisResult != AnalysisResult.Ok:
+    if analysisResult == AnalysisResult.Ok:
+        if len(sourceFiles) > 1:
+            return reinvokePerSourceFile(cmdLine, sourceFiles), '', ''
+        else:
+            if 'CLCACHE_NODIRECT' in os.environ:
+                return processNoDirect(cache, outputFile, compiler, cmdLine)
+            else:
+                return processDirect(cache, outputFile, compiler, cmdLine, sourceFiles[0])
+    else:
         with cache.lock:
             stats = CacheStatistics(cache)
             if analysisResult == AnalysisResult.NoSourceFile:
@@ -1276,11 +1281,6 @@ def processCompileRequest(cache, compiler, args):
                 stats.registerCallForExternalDebugInfo()
             stats.save()
         return invokeRealCompiler(compiler, args[1:])
-
-    if 'CLCACHE_NODIRECT' in os.environ:
-        return processNoDirect(cache, outputFile, compiler, cmdLine)
-    else:
-        return processDirect(cache, outputFile, compiler, cmdLine, sourceFiles[0])
 
 
 def processDirect(cache, outputFile, compiler, cmdLine, sourceFile):

--- a/unittests.py
+++ b/unittests.py
@@ -160,24 +160,24 @@ class TestAnalyzeCommandLine(BaseTest):
         result, _, _ = CommandLineAnalyzer.analyze(cmdLine)
         self.assertEqual(result, expectedResult)
 
-    def _testFull(self, cmdLine, expectedResult, expectedSourceFile, expectedOutputFile):
-        result, sourceFile, outputFile = CommandLineAnalyzer.analyze(cmdLine)
+    def _testFull(self, cmdLine, expectedResult, expectedSourceFiles, expectedOutputFile):
+        result, sourceFiles, outputFile = CommandLineAnalyzer.analyze(cmdLine)
         self.assertEqual(result, expectedResult)
-        self.assertEqual(sourceFile, expectedSourceFile)
+        self.assertEqual(sourceFiles, expectedSourceFiles)
         self.assertEqual(outputFile, expectedOutputFile)
 
     def _testFo(self, foArgument, expectedObjectFilepath):
         self._testFull(['/c', foArgument, 'main.cpp'],
-                       AnalysisResult.Ok, "main.cpp", expectedObjectFilepath)
+                       AnalysisResult.Ok, ["main.cpp"], expectedObjectFilepath)
 
     def _testFi(self, fiArgument, expectedOutputFile):
         self._testFull(['/c', '/P', fiArgument, 'main.cpp'],
-                       AnalysisResult.Ok, "main.cpp", expectedOutputFile)
+                       AnalysisResult.Ok, ["main.cpp"], expectedOutputFile)
         self._testFull(['/c', '/P', '/EP', fiArgument, 'main.cpp'],
-                       AnalysisResult.Ok, "main.cpp", expectedOutputFile)
+                       AnalysisResult.Ok, ["main.cpp"], expectedOutputFile)
 
     def _testPreprocessingOutfile(self, cmdLine, expectedOutputFile):
-        self._testFull(cmdLine, AnalysisResult.Ok, 'main.cpp', expectedOutputFile)
+        self._testFull(cmdLine, AnalysisResult.Ok, ['main.cpp'], expectedOutputFile)
 
     def testEmpty(self):
         self._testShort([], AnalysisResult.NoSourceFile)
@@ -193,10 +193,10 @@ class TestAnalyzeCommandLine(BaseTest):
     def testOutputFileFromSourcefile(self):
         # For object file
         self._testFull(['/c', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', 'main.obj')
+                       AnalysisResult.Ok, ['main.cpp'], 'main.obj')
         # For preprocessor file
         self._testFull(['/c', '/P', 'main.cpp'],
-                       AnalysisResult.Ok, 'main.cpp', 'main.i')
+                       AnalysisResult.Ok, ['main.cpp'], 'main.i')
 
     def testPreprocessIgnoresOtherArguments(self):
         # All those inputs must ignore the /Fo, /Fa and /Fm argument according
@@ -281,9 +281,9 @@ class TestAnalyzeCommandLine(BaseTest):
     def testTpTcSimple(self):
         # clcache can handle /Tc or /Tp as long as there is only one of them
         self._testFull(['/c', '/TcMyCcProgram.c'],
-                       AnalysisResult.Ok, 'MyCcProgram.c', 'MyCcProgram.obj')
+                       AnalysisResult.Ok, ['MyCcProgram.c'], 'MyCcProgram.obj')
         self._testFull(['/c', '/TpMyCxxProgram.cpp'],
-                       AnalysisResult.Ok, 'MyCxxProgram.cpp', 'MyCxxProgram.obj')
+                       AnalysisResult.Ok, ['MyCxxProgram.cpp'], 'MyCxxProgram.obj')
 
     def testLink(self):
         self._testShort(["main.cpp"], AnalysisResult.CalledForLink)


### PR DESCRIPTION
analyze() returned a list of source files or None in all cases but
AnalysisResult.Ok. This commit ensures that the second return value is
always a list. This is important because the second return value is
stored in a local variable at a point where we don't yet know the
analysis result. This local variable now has a proper plural name
`sourceFiles`.