### PR TITLE
Test parsing of arguments starting with backslash

### DIFF
--- a/unittests.py
+++ b/unittests.py
@@ -148,6 +148,12 @@ class TestSplitCommandsFile(BaseTest):
         self._genericTest('-A\r\n-B', ['-A', '-B'])
         self._genericTest('-A -B\r\n-C -D -E', ['-A', '-B', '-C', '-D', '-E'])
 
+    def testInitialBackslash(self):
+        self._genericTest(r'/Fo"C:\out dir\"', [r'/FoC:\out dir"'])
+        self._genericTest(r'\foo.cpp', [r'\foo.cpp'])
+        self._genericTest(r'/nologo \foo.cpp', [r'/nologo', r'\foo.cpp'])
+        self._genericTest(r'\foo.cpp /c', [r'\foo.cpp', r'/c'])
+
 
 class TestAnalyzeCommandLine(BaseTest):
     def _testShort(self, cmdLine, expectedResult):


### PR DESCRIPTION
Looking at the coverage of the TestSplitCommandsFile test case showed
that the only statements in the CommandLineTokenizer which were not
covered yet were the ones handling the case that some argument *starts*
with a backslash.

A real-life scenario of this situation is when source files are in the
root directory (not uncommon when using the 'subst' command), e.g.

  C:\>subst X: C:\Users\Frerich\src\fooproject

  C:\>X:

  X:\>cl \foo.cpp

Let's add a test for this, so all statements have been covered according
to Coverage.py.