### PR TITLE
Add Makefile for local lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: lint-clcache lint-unittests lint-integrationtests lint
+
+lint-clcache:
+	pylint --rcfile .pylintrc clcache.py
+
+lint-unittests:
+	pylint --rcfile .pylintrc unittests.py
+
+lint-integrationtests:
+	pylint --rcfile .pylintrc integrationtests.py
+
+lint: lint-clcache lint-unittests lint-integrationtests

--- a/clcache.py
+++ b/clcache.py
@@ -192,7 +192,7 @@ class ObjectCache(object):
         for o in objects:
             try:
                 objectInfos.append((os.stat(o), o))
-            except WindowsError:
+            except OSError:
                 pass
 
         objectInfos.sort(key=lambda t: t[0].st_atime)


### PR DESCRIPTION
This allows you to run lint locally in a very convenient way.

Linux/OS X:
* `make lint`
* `make lint -j 3` (parallel linting in 3 jobs)

Windows:
* `nmake lint`
* `jom lint -j 3` (parallel linting in 3 jobs)