### PR TITLE
Publish coverage reports for tests at codecov.io

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -14,6 +14,7 @@ relay the invocation to the real 'cl.exe' program.
 
 image::https://ci.appveyor.com/api/projects/status/sf98y2686r00q6ga/branch/master?svg=true[Build status, link="https://ci.appveyor.com/project/frerich/clcache"]
 image:https://www.quantifiedcode.com/api/v1/project/652606d7e4a94db0bf2da6f0e5778c94/badge.svg[Code issues, link="https://www.quantifiedcode.com/app/project/652606d7e4a94db0bf2da6f0e5778c94"]
+image:https://codecov.io/gh/frerich/clcache/branch/master/graph/badge.svg[]
 
 Installation
 ~~~~~~~~~~~~

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,12 @@ install:
   - pip install pylint
   - pylint --version
 
+  # Install coverage plugin for pytest
+  - pip install pytest-cov
+
+  # Install tool for uploading coverage data to codecov.io
+  - pip install codecov
+
 build_script:
   - python clcache.py --help
   - python clcache.py -s
@@ -45,22 +51,26 @@ build_script:
 
 test_script:
   # Run test files via py.test and generate JUnit XML. Then push test results
-  # to appveyor.
+  # to appveyor. Coverage information is stored in a .coverage file.
   - ps: |
-      & py.test --junitxml .\unittests.xml unittests.py
+      & py.test --junitxml .\unittests.xml unittests.py --cov=clcache
       $testsExitCode = $lastexitcode
 
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\unittests.xml))
 
+      & codecov --no-color -X gcov -F unittests -e PYTHON_INSTALL
+
       if ($testsExitCode -ne 0) {exit $testsExitCode}
 
   - ps: |
-      & py.test --junitxml .\integrationtests.xml integrationtests.py
+      & py.test --junitxml .\integrationtests.xml integrationtests.py --cov=clcache
       $testsExitCode = $lastexitcode
 
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\integrationtests.xml))
+
+      & codecov --no-color -X gcov -F integration -e PYTHON_INSTALL
 
       if ($testsExitCode -ne 0) {exit $testsExitCode}
 


### PR DESCRIPTION
An initial attempt at generating coverage reports during CI runs.
Ideally, I'd like to have a single HTML coverage report telling me which
parts of clcache.py were hit (and not hit) when executing both unit- as
well as integration tests.

For now, we limit ourselves to:

1. Only collecting coverage data when running unit tests
2. Generating HTML, but offering the artifact as a .zip file

Let's see how it goes.