### PR TITLE
Refactor analysis

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -844,12 +844,12 @@ class CommandLineAnalyzer(object):
             sourceFiles += options['Tc']
             compl = True
 
+        if len(sourceFiles) == 0:
+            raise NoSourceFileError()
+
         for opt in ['E', 'EP', 'P']:
             if opt in options:
                 raise CalledForPreprocessingError()
-
-        if len(sourceFiles) == 0:
-            raise NoSourceFileError()
 
         # Technically, it would be possible to support /Zi: we'd just need to
         # copy the generated .pdb files into/out of the cache.

--- a/clcache.py
+++ b/clcache.py
@@ -804,10 +804,10 @@ class CommandLineAnalyzer(object):
             arg = cmdline[i]
 
             # Plain arguments starting with / or -
-            if arg[0] == '/' or arg[0] == '-':
+            if arg.startswith('/') or arg.startswith('-'):
                 isParametrized = False
                 for opt in optionsWithParameterSorted:
-                    if arg[1:len(opt) + 1] == opt:
+                    if arg.startswith(opt, 1):
                         isParametrized = True
                         key = opt
                         if len(arg) > len(opt) + 1:

--- a/unittests.py
+++ b/unittests.py
@@ -182,9 +182,15 @@ class TestAnalyzeCommandLine(BaseTest):
         self._testFull(["/c", "main.cpp"], ["main.cpp"], "main.obj")
 
     def testNoSource(self):
-        self._testFailure(['/c'], NoSourceFileError)
+        # No source file is the worst thing that can happen. In this case there
+        # is no chance we can help, so it has priority over other errors.
         self._testFailure(['/c', '/nologo'], NoSourceFileError)
-        self._testFailure(['/c', '/nologo', '/Zi'], NoSourceFileError)
+        self._testFailure(['/c'], NoSourceFileError)
+        self._testFailure([], NoSourceFileError)
+        self._testFailure(['/Zi'], NoSourceFileError)
+        self._testFailure(['/E'], NoSourceFileError)
+        self._testFailure(['/P'], NoSourceFileError)
+        self._testFailure(['/EP'], NoSourceFileError)
 
     def testOutputFileFromSourcefile(self):
         # For object file


### PR DESCRIPTION
This is just one minor step towards /Zi.

On the way I found a bug when handling optional filepath parameters, e.g. in [/Yc](https://msdn.microsoft.com/en-us/library/7zc28563.aspx).

What I have in here is everything I could finish before dealing with the bug.