### PR TITLE
Optional argument parameter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -61,7 +61,8 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=old-ne-operator,zip-builtin-not-iterating,filter-builtin-not-iterating,metaclass-assignment,cmp-method,raw_input-builtin,parameter-unpacking,standarderror-builtin,input-builtin,cmp-builtin,no-absolute-import,round-builtin,coerce-method,file-builtin,import-star-module-level,long-suffix,using-cmp-argument,old-division,reduce-builtin,raising-string,dict-view-method,map-builtin-not-iterating,nonzero-method,buffer-builtin,unicode-builtin,setslice-method,old-octal-literal,range-builtin-not-iterating,apply-builtin,useless-suppression,getslice-method,backtick,intern-builtin,unichr-builtin,unpacking-in-except,next-method-called,dict-iter-method,reload-builtin,coerce-builtin,hex-method,basestring-builtin,old-raise-syntax,execfile-builtin,long-builtin,xrange-builtin,print-statement,delslice-method,oct-method,suppressed-message,indexing-exception,
-  missing-docstring
+  missing-docstring,
+  unidiomatic-typecheck
 
 [REPORTS]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -315,7 +315,7 @@ max-returns=20
 max-branches=20
 
 # Maximum number of statements in function / method body
-max-statements=50
+max-statements=100
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/.pylintrc
+++ b/.pylintrc
@@ -327,7 +327,7 @@ max-attributes=7
 min-public-methods=0
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=30
+max-public-methods=50
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ clcache changelog
  * Bugfix: Properly handle /Fi arguments
  * Dropped support for caching preprocessor invocations. The number of such
    invocations is now printed in the statistics (`ccache -s`).
+ * Bugfix: In MSVS, arguments use the formats `/NAMEparameter` (no space, required value),
+   `/NAME[parameter]` (no space, optional value), `/NAME[ ]parameter` (optional space),
+   and `/NAME parameter` (required space). Before we always tried `/NAMEparameter`
+   and if there if no parameter, tried `/NAME parameter`. This strategy was too simple
+   and failed for like e.g. `/Fo`, which must not consume the following argument when
+   no parameter is set.
 
 ## clcache 3.1.1 (2016-06-25)
 

--- a/clcache.py
+++ b/clcache.py
@@ -552,6 +552,10 @@ class CalledForPreprocessingError(AnalysisError):
     pass
 
 
+class InvalidArgumentError(AnalysisError):
+    pass
+
+
 def getCompilerHash(compilerBinary):
     stat = os.stat(compilerBinary)
     data = '|'.join([
@@ -772,6 +776,9 @@ class Argument(object):
     def __len__(self):
         return len(self.name)
 
+    def __str__(self):
+        return "/" + self.name
+
     def __eq__(self, other):
         return type(self) == type(other) and self.name == other.name
 
@@ -835,11 +842,23 @@ class CommandLineAnalyzer(object):
                 for arg in argumentsWithParameterSorted:
                     if cmdLineArgument.startswith(arg.name, 1):
                         isParametrized = True
-                        if len(cmdLineArgument) > len(arg) + 1:
+                        if isinstance(arg, ArgumentT1):
                             value = cmdLineArgument[len(arg) + 1:]
-                        else:
+                            if not value:
+                                raise InvalidArgumentError("Parameter for {} must not be empty".format(arg))
+                        elif isinstance(arg, ArgumentT2):
+                            value = cmdLineArgument[len(arg) + 1:]
+                        elif isinstance(arg, ArgumentT3):
+                            value = cmdLineArgument[len(arg) + 1:]
+                            if not value:
+                                value = cmdline[i + 1]
+                                i += 1
+                        elif isinstance(arg, ArgumentT4):
                             value = cmdline[i + 1]
                             i += 1
+                        else:
+                            raise AssertionError("Unsupported argument type.")
+
                         arguments[arg.name].append(value)
                         break
 

--- a/clcache.py
+++ b/clcache.py
@@ -765,19 +765,61 @@ def expandCommandLine(cmdline):
     return ret
 
 
+class Argument(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __len__(self):
+        return len(self.name)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.name == other.name
+
+    def __hash__(self):
+        key = (type(self), self.name)
+        return hash(key)
+
+
+# /NAMEparameter (no space, required parameter).
+class ArgumentT1(Argument):
+    pass
+
+
+# /NAME[parameter] (no space, optional parameter)
+class ArgumentT2(Argument):
+    pass
+
+
+# /NAME[ ]parameter (optional space)
+class ArgumentT3(Argument):
+    pass
+
+
+# /NAME parameter (required space)
+class ArgumentT4(Argument):
+    pass
+
+
 class CommandLineAnalyzer(object):
 
     @staticmethod
     def parseArgumentsAndInputFiles(cmdline):
         argumentsWithParameter = {
-            'Ob', 'Gs', 'Fa', 'Fd', 'Fm',
-            'Fp', 'FR', 'doc', 'FA', 'Fe',
-            'Fo', 'Fr', 'AI', 'FI', 'FU',
-            'D', 'U', 'I', 'Zp',
-            'MP', 'Tc', 'V', 'wd', 'wo',
-            'W', 'Yc', 'Yl', 'Tp', 'we',
-            'w1', 'w2', 'w3', 'w4', 'Wv',
-            'Yu', 'Zm', 'F', 'Fi',
+            # /NAMEparameter
+            ArgumentT1('Ob'), ArgumentT1('Yl'), ArgumentT1('Zm'),
+            # /NAME[parameter]
+            ArgumentT2('doc'), ArgumentT2('FA'), ArgumentT2('FR'), ArgumentT2('Fr'),
+            ArgumentT2('Gs'), ArgumentT2('MP'), ArgumentT2('Yc'), ArgumentT2('Yu'),
+            ArgumentT2('Zp'), ArgumentT2('Fa'), ArgumentT2('Fd'), ArgumentT2('Fe'),
+            ArgumentT2('Fi'), ArgumentT2('Fm'), ArgumentT2('Fo'), ArgumentT2('Fp'),
+            ArgumentT2('Wv'),
+            # /NAME[ ]parameter
+            ArgumentT3('AI'), ArgumentT3('D'), ArgumentT3('Tc'), ArgumentT3('Tp'),
+            ArgumentT3('FI'), ArgumentT3('U'), ArgumentT3('I'), ArgumentT3('F'),
+            ArgumentT3('FU'), ArgumentT3('w1'), ArgumentT3('w2'), ArgumentT3('w3'),
+            ArgumentT3('w4'), ArgumentT3('wd'), ArgumentT3('we'), ArgumentT3('wo'),
+            ArgumentT3('V'),
+            # /NAME parameter
         }
         # Sort by length to handle prefixes
         argumentsWithParameterSorted = sorted(argumentsWithParameter, key=len, reverse=True)
@@ -791,14 +833,14 @@ class CommandLineAnalyzer(object):
             if cmdLineArgument.startswith('/') or cmdLineArgument.startswith('-'):
                 isParametrized = False
                 for arg in argumentsWithParameterSorted:
-                    if cmdLineArgument.startswith(arg, 1):
+                    if cmdLineArgument.startswith(arg.name, 1):
                         isParametrized = True
                         if len(cmdLineArgument) > len(arg) + 1:
                             value = cmdLineArgument[len(arg) + 1:]
                         else:
                             value = cmdline[i + 1]
                             i += 1
-                        arguments[arg].append(value)
+                        arguments[arg.name].append(value)
                         break
 
                 if not isParametrized:

--- a/clcache.py
+++ b/clcache.py
@@ -867,7 +867,7 @@ class CommandLineAnalyzer(object):
                     arguments[arg.name].append(value)
                 else:
                     argumentName = cmdLineArgument[1:] # name not followed by parameter in this case
-                    arguments[argumentName] = []
+                    arguments[argumentName].append('')
 
             # Response file
             elif cmdLineArgument[0] == '@':

--- a/clcache.py
+++ b/clcache.py
@@ -921,7 +921,7 @@ class CommandLineAnalyzer(object):
             raise MultipleSourceFilesComplexError()
 
         if len(inputFiles) == 1:
-            if 'Fo' in options:
+            if 'Fo' in options and options['Fo'][0]:
                 # Handle user input
                 objectFile = os.path.normpath(options['Fo'][0])
                 if os.path.isdir(objectFile):

--- a/unittests.py
+++ b/unittests.py
@@ -80,6 +80,38 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(clcache.basenameWithoutExtension(r"C:\Project\README.asciidoc.tmp"), "README.asciidoc")
 
 
+class TestArgumentClasses(unittest.TestCase):
+    def testEquality(self):
+        self.assertEqual(clcache.ArgumentT1('Fo'), clcache.ArgumentT1('Fo'))
+        self.assertEqual(clcache.ArgumentT1('W'), clcache.ArgumentT1('W'))
+        self.assertEqual(clcache.ArgumentT2('W'), clcache.ArgumentT2('W'))
+        self.assertEqual(clcache.ArgumentT3('W'), clcache.ArgumentT3('W'))
+        self.assertEqual(clcache.ArgumentT4('W'), clcache.ArgumentT4('W'))
+
+        self.assertNotEqual(clcache.ArgumentT1('Fo'), clcache.ArgumentT1('W'))
+        self.assertNotEqual(clcache.ArgumentT1('Fo'), clcache.ArgumentT1('FO'))
+
+        self.assertNotEqual(clcache.ArgumentT1('W'), clcache.ArgumentT2('W'))
+        self.assertNotEqual(clcache.ArgumentT2('W'), clcache.ArgumentT3('W'))
+        self.assertNotEqual(clcache.ArgumentT3('W'), clcache.ArgumentT4('W'))
+        self.assertNotEqual(clcache.ArgumentT4('W'), clcache.ArgumentT1('W'))
+
+    def testHash(self):
+        self.assertEqual(hash(clcache.ArgumentT1('Fo')), hash(clcache.ArgumentT1('Fo')))
+        self.assertEqual(hash(clcache.ArgumentT1('W')), hash(clcache.ArgumentT1('W')))
+        self.assertEqual(hash(clcache.ArgumentT2('W')), hash(clcache.ArgumentT2('W')))
+        self.assertEqual(hash(clcache.ArgumentT3('W')), hash(clcache.ArgumentT3('W')))
+        self.assertEqual(hash(clcache.ArgumentT4('W')), hash(clcache.ArgumentT4('W')))
+
+        self.assertNotEqual(hash(clcache.ArgumentT1('Fo')), hash(clcache.ArgumentT1('W')))
+        self.assertNotEqual(hash(clcache.ArgumentT1('Fo')), hash(clcache.ArgumentT1('FO')))
+
+        self.assertNotEqual(hash(clcache.ArgumentT1('W')), hash(clcache.ArgumentT2('W')))
+        self.assertNotEqual(hash(clcache.ArgumentT2('W')), hash(clcache.ArgumentT3('W')))
+        self.assertNotEqual(hash(clcache.ArgumentT3('W')), hash(clcache.ArgumentT4('W')))
+        self.assertNotEqual(hash(clcache.ArgumentT4('W')), hash(clcache.ArgumentT1('W')))
+
+
 class TestSplitCommandsFile(unittest.TestCase):
     def _genericTest(self, commandLine, expected):
         self.assertEqual(clcache.splitCommandsFile(commandLine), expected)

--- a/unittests.py
+++ b/unittests.py
@@ -417,20 +417,108 @@ class TestAnalyzeCommandLine(unittest.TestCase):
 
     def testParseArgumentsAndInputFiles(self):
         self._testArgInfiles(['/c', 'main.cpp'],
-                             {'c': []},
+                             {'c': ['']},
                              ['main.cpp'])
         self._testArgInfiles(['/link', 'unit1.obj', 'unit2.obj'],
-                             {'link': []},
+                             {'link': ['']},
                              ['unit1.obj', 'unit2.obj'])
         self._testArgInfiles(['/Fooutfile.obj', 'main.cpp'],
                              {'Fo': ['outfile.obj']},
                              ['main.cpp'])
+        self._testArgInfiles(['/Fo', '/Fooutfile.obj', 'main.cpp'],
+                             {'Fo': ['', 'outfile.obj']},
+                             ['main.cpp'])
         self._testArgInfiles(['/c', '/I', 'somedir', 'main.cpp'],
-                             {'c': [], 'I': ['somedir']},
+                             {'c': [''], 'I': ['somedir']},
                              ['main.cpp'])
         self._testArgInfiles(['/c', '/I.', '/I', 'somedir', 'main.cpp'],
-                             {'c': [], 'I': ['.', 'somedir']},
+                             {'c': [''], 'I': ['.', 'somedir']},
                              ['main.cpp'])
+
+        # Type 1 (/NAMEparameter) - Arguments with required parameter
+        # get parameter=99
+        self._testArgInfiles(["/c", "/Ob99", "main.cpp"], {'c': [''], 'Ob': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Yl99", "main.cpp"], {'c': [''], 'Yl': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Zm99", "main.cpp"], {'c': [''], 'Zm': ['99']}, ['main.cpp'])
+
+        # # Type 2 (/NAME[parameter]) - Optional argument parameters
+        # get parameter=99
+        self._testArgInfiles(["/c", "/doc99", "main.cpp"], {'c': [''], 'doc': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/FA99", "main.cpp"], {'c': [''], 'FA': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fr99", "main.cpp"], {'c': [''], 'Fr': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/FR99", "main.cpp"], {'c': [''], 'FR': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Gs99", "main.cpp"], {'c': [''], 'Gs': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/MP99", "main.cpp"], {'c': [''], 'MP': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Wv99", "main.cpp"], {'c': [''], 'Wv': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Yc99", "main.cpp"], {'c': [''], 'Yc': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Yu99", "main.cpp"], {'c': [''], 'Yu': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Zp99", "main.cpp"], {'c': [''], 'Zp': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fa99", "main.cpp"], {'c': [''], 'Fa': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fd99", "main.cpp"], {'c': [''], 'Fd': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fe99", "main.cpp"], {'c': [''], 'Fe': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fi99", "main.cpp"], {'c': [''], 'Fi': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fm99", "main.cpp"], {'c': [''], 'Fm': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fo99", "main.cpp"], {'c': [''], 'Fo': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fp99", "main.cpp"], {'c': [''], 'Fp': ['99']}, ['main.cpp'])
+        # get no parameter
+        self._testArgInfiles(["/c", "/doc", "main.cpp"], {'c': [''], 'doc': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/FA", "main.cpp"], {'c': [''], 'FA': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fr", "main.cpp"], {'c': [''], 'Fr': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/FR", "main.cpp"], {'c': [''], 'FR': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Gs", "main.cpp"], {'c': [''], 'Gs': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/MP", "main.cpp"], {'c': [''], 'MP': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Wv", "main.cpp"], {'c': [''], 'Wv': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Yc", "main.cpp"], {'c': [''], 'Yc': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Yu", "main.cpp"], {'c': [''], 'Yu': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Zp", "main.cpp"], {'c': [''], 'Zp': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fa", "main.cpp"], {'c': [''], 'Fa': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fd", "main.cpp"], {'c': [''], 'Fd': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fe", "main.cpp"], {'c': [''], 'Fe': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fi", "main.cpp"], {'c': [''], 'Fi': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fm", "main.cpp"], {'c': [''], 'Fm': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fo", "main.cpp"], {'c': [''], 'Fo': ['']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Fp", "main.cpp"], {'c': [''], 'Fp': ['']}, ['main.cpp'])
+
+        # Type 3 (/NAME[ ]parameter) - Required argument parameters with optional space
+        # get space
+        self._testArgInfiles(["/c", "/FI", "99", "main.cpp"], {'c': [''], 'FI': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/U", "99", "main.cpp"], {'c': [''], 'U': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/I", "99", "main.cpp"], {'c': [''], 'I': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/F", "99", "main.cpp"], {'c': [''], 'F': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/FU", "99", "main.cpp"], {'c': [''], 'FU': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w1", "99", "main.cpp"], {'c': [''], 'w1': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w2", "99", "main.cpp"], {'c': [''], 'w2': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w3", "99", "main.cpp"], {'c': [''], 'w3': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w4", "99", "main.cpp"], {'c': [''], 'w4': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/wd", "99", "main.cpp"], {'c': [''], 'wd': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/we", "99", "main.cpp"], {'c': [''], 'we': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/wo", "99", "main.cpp"], {'c': [''], 'wo': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/AI", "99", "main.cpp"], {'c': [''], 'AI': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/D", "99", "main.cpp"], {'c': [''], 'D': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/V", "99", "main.cpp"], {'c': [''], 'V': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Tc", "99", "main.cpp"], {'c': [''], 'Tc': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Tp", "99", "main.cpp"], {'c': [''], 'Tp': ['99']}, ['main.cpp'])
+        # don't get space
+        self._testArgInfiles(["/c", "/FI99", "main.cpp"], {'c': [''], 'FI': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/U99", "main.cpp"], {'c': [''], 'U': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/I99", "main.cpp"], {'c': [''], 'I': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/F99", "main.cpp"], {'c': [''], 'F': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/FU99", "main.cpp"], {'c': [''], 'FU': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w199", "main.cpp"], {'c': [''], 'w1': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w299", "main.cpp"], {'c': [''], 'w2': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w399", "main.cpp"], {'c': [''], 'w3': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/w499", "main.cpp"], {'c': [''], 'w4': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/wd99", "main.cpp"], {'c': [''], 'wd': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/we99", "main.cpp"], {'c': [''], 'we': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/wo99", "main.cpp"], {'c': [''], 'wo': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/AI99", "main.cpp"], {'c': [''], 'AI': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/D99", "main.cpp"], {'c': [''], 'D': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/V99", "main.cpp"], {'c': [''], 'V': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Tc99", "main.cpp"], {'c': [''], 'Tc': ['99']}, ['main.cpp'])
+        self._testArgInfiles(["/c", "/Tp99", "main.cpp"], {'c': [''], 'Tp': ['99']}, ['main.cpp'])
+
+        # Type 4 (/NAME parameter) - Forced space
+        # Some documented, but non implemented
 
 
 class TestMultipleSourceFiles(unittest.TestCase):

--- a/unittests.py
+++ b/unittests.py
@@ -231,8 +231,8 @@ class TestAnalyzeCommandLine(unittest.TestCase):
         self._testFull(["/c", "main.cpp"], ["main.cpp"], "main.obj")
 
     def testNoSource(self):
-        # No source file is the worst thing that can happen. In this case there
-        # is no chance we can help, so it has priority over other errors.
+        # No source file has priority over other errors, for consistency
+        # and because it's likely to be a misconfigured command line.
         self._testFailure(['/c', '/nologo'], NoSourceFileError)
         self._testFailure(['/c'], NoSourceFileError)
         self._testFailure([], NoSourceFileError)
@@ -240,6 +240,9 @@ class TestAnalyzeCommandLine(unittest.TestCase):
         self._testFailure(['/E'], NoSourceFileError)
         self._testFailure(['/P'], NoSourceFileError)
         self._testFailure(['/EP'], NoSourceFileError)
+        self._testFailure(['/Yc'], NoSourceFileError)
+        self._testFailure(['/Yu'], NoSourceFileError)
+        self._testFailure(['/link'], NoSourceFileError)
 
     def testOutputFileFromSourcefile(self):
         # For object file


### PR DESCRIPTION
In MSVS, arguments use the formats `/NAME[ ]value` (optional space), `/NAME value` (required space), `/NAME[value]` (no space, optional value), `/NAMEvalue` (no space, required value).

Right now we always try `/NAMEvalue` and if there if no value, try  `/NAME value`. This strategy is too simple and fails for `/doc`, which must not consume the following argument when no value is set.

I guess we need to group the arguments in those four categories and handle them accordingly.