### PR TITLE
Adding .coveragerc file to customize Coverage.py behaviour

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+include = clcache.py


### PR DESCRIPTION
It seems this is picked up by Coverage.py automatically (which we invoke
indirectly via the py.test coverage plugin). It makes it generate branch
coverage information, which is more useful than statement coverage.