### PR TITLE
Fix/piped output

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -86,6 +86,14 @@ Manifest = namedtuple('Manifest', ['includeFiles', 'hashes'])
 
 
 def printBinary(rawData, stream):
+    # See http://stackoverflow.com/questions/2374427/python-2-x-write-binary-output-to-stdout
+    if sys.version_info[0] < 3:
+        # msvcrt and O_BINARY are only available on Windows, but we like to
+        # use pylint on Unix developer machines to speed-up development, thus
+        # we disable some lint error on a per-line base here.
+        import msvcrt # pylint: disable=import-error
+        msvcrt.setmode(stream.fileno(), os.O_BINARY) # pylint: disable=no-member
+
     with os.fdopen(stream.fileno(), 'wb') as fp:
         fp.write(rawData)
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -151,6 +151,29 @@ class TestCompileRuns(BaseTest):
         subprocess.check_call(cmd) # Compile once
         subprocess.check_call(cmd) # Compile again
 
+    def testPipedOutput(self):
+        commands = [
+            # passed to real compiler
+            [PYTHON_BINARY, CLCACHE_SCRIPT, '/?'],
+            [PYTHON_BINARY, CLCACHE_SCRIPT, '/E', 'fibonacci.c'],
+            # Unique parameters ensure this was not cached yet (at least in CI)
+            [PYTHON_BINARY, CLCACHE_SCRIPT, '/wd4267', '/wo4018', '/c', 'fibonacci.c'],
+            # Cache hit
+            [PYTHON_BINARY, CLCACHE_SCRIPT, '/wd4267', '/wo4018', '/c', 'fibonacci.c'],
+        ]
+
+        with cd(ASSETS_DIR):
+            for cmd in commands:
+                try:
+                    output = subprocess.check_output(cmd).decode(clcache.CL_DEFAULT_CODEC)
+                except subprocess.CalledProcessError as e:
+                    self.fail('{}\nOutput:\n{}'.format(e, e.output))
+                self.assertTrue('\r\r\n' not in output,
+                                'Command:{}\nOutput has duplicated CR: {}'.format(cmd, output))
+                # Just to be sure we have newlines
+                self.assertTrue('\r\n' in output,
+                                'Command:{}\nOutput has no CRLF: {}'.format(cmd, output))
+
 
 class TestCompilerEncoding(BaseTest):
     def testNonAsciiMessage(self):


### PR DESCRIPTION
After [MBCS decoding/encoding](https://github.com/frerich/clcache/commit/5514b7b30f14a11f4ed60d6777d812fad55a7406) clcache started to output duplicated CR chars.
I think this is due to Windows C API which automatically converts LF to CRLF
More info on https://github.com/ninja-build/ninja/issues/773 and https://connect.microsoft.com/VisualStudio/feedback/details/523174/c-library-fprintf-and-fwrite-convert-line-endings-incorrectly