### PR TITLE
Fix variable declaration non-conformant to C89

### DIFF
--- a/tests/integrationtests/fibonacci.c
+++ b/tests/integrationtests/fibonacci.c
@@ -6,9 +6,8 @@ void print_fib(int n)
     int b = 1;
     while (a < n)
     {
-        printf("%d ", a);
-
         int old_a = a;
+        printf("%d ", a);
         a = b;
         b = old_a + b;
     }


### PR DESCRIPTION
Declaring variables on C89 need to be done at the beginning of the
function scope. The old code failed on VS2010.