### PR TITLE
Remove cPickle import

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -9,14 +9,11 @@
 from ctypes import windll, wintypes
 import codecs
 from collections import defaultdict, namedtuple
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 import errno
 import hashlib
 import json
 import os
+import pickle
 from shutil import copyfile, rmtree
 import subprocess
 from subprocess import Popen, PIPE


### PR DESCRIPTION
This is obsolete since we don't support Python 2 anymore.

"In Python 2, you can speed up your pickle access with cPickle. (In
Python3, importing pickle will automatically use the accelerated version
if it is available.)" https://wiki.python.org/moin/UsingPickle