### PR TITLE
Resolved code duplication when handling cache hits

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -1393,17 +1393,7 @@ def processNoDirect(cache, outputFile, compiler, cmdLine):
     cachekey = ObjectCache.computeKey(compiler, cmdLine)
     with cache.lock:
         if cache.hasEntry(cachekey):
-            stats = CacheStatistics(cache)
-            stats.registerCacheHit()
-            stats.save()
-            printTraceStatement("Reusing cached object for key {} for output file {}".format(cachekey, outputFile))
-            if outputFile is not None and os.path.exists(outputFile):
-                os.remove(outputFile)
-            copyOrLink(cache.cachedObjectName(cachekey), outputFile)
-            compilerStdout = cache.cachedCompilerOutput(cachekey)
-            compilerStderr = cache.cachedCompilerStderr(cachekey)
-            printTraceStatement("Finished. Exit code 0")
-            return 0, compilerStdout, compilerStderr
+            return processCacheHit(cache, outputFile, cachekey)
 
     returnCode, compilerStdout, compilerStderr = invokeRealCompiler(compiler, cmdLine, captureOutput=True)
     with cache.lock:

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -459,6 +459,23 @@ class TestNoDirectCalls(unittest.TestCase):
         self.assertEqual(clcache.CacheStatistics(cache), oldStats)
         self.assertNotEqual(p.returncode, 0)
 
+    def testHit(self):
+        with cd(os.path.join(ASSETS_DIR, "hits-and-misses")):
+            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c", "hit.cpp"]
+            env = dict(os.environ, CLCACHE_NODIRECT="1")
+
+            p = subprocess.Popen(cmd, env=env)
+            p.wait()
+            self.assertEqual(p.returncode, 0)
+
+            cache = clcache.ObjectCache()
+            oldHits = clcache.CacheStatistics(cache).numCacheHits()
+
+            p = subprocess.Popen(cmd, env=env)
+            p.wait() # This should hit now
+            self.assertEqual(p.returncode, 0)
+            self.assertEqual(clcache.CacheStatistics(cache).numCacheHits(), oldHits + 1)
+
 
 if __name__ == '__main__':
     unittest.TestCase.longMessage = True


### PR DESCRIPTION
The actions taken when executing a cache hit (copying the cache
artefacts, updating the stats) were duplicated between direct and
indirect hits. Let's fix that.