### PR TITLE
Manifest sections

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -125,9 +125,6 @@ class ManifestsManager(object):
     def manifestSection(self, manifestHash):
         return ManifestSection(os.path.join(self._manifestsRootDir, manifestHash[:2]))
 
-    def manifestDir(self, manifestHash):
-        return self.manifestSection(manifestHash).manifestSectionDir
-
     def manifestPath(self, manifestHash):
         return self.manifestSection(manifestHash).manifestPath(manifestHash)
 

--- a/clcache.py
+++ b/clcache.py
@@ -93,6 +93,9 @@ class ManifestSection(object):
     def manifestPath(self, manifestHash):
         return os.path.join(self.manifestSectionDir, manifestHash + ".json")
 
+    def manifestFiles(self):
+        return filesBeneath(self.manifestSectionDir)
+
     def setManifest(self, manifestHash, manifest):
         ensureDirectoryExists(self.manifestSectionDir)
         with open(self.manifestPath(manifestHash), 'w') as outFile:
@@ -133,11 +136,12 @@ class ManifestsManager(object):
 
     def clean(self, maxManifestsSize):
         manifestFileInfos = []
-        for filepath in filesBeneath(self._manifestsRootDir):
-            try:
-                manifestFileInfos.append((os.stat(filepath), filepath))
-            except OSError:
-                pass
+        for section in self.manifestSections():
+            for filePath in section.manifestFiles():
+                try:
+                    manifestFileInfos.append((os.stat(filePath), filePath))
+                except OSError:
+                    pass
 
         manifestFileInfos.sort(key=lambda t: t[0].st_atime, reverse=True)
 

--- a/clcache.py
+++ b/clcache.py
@@ -134,9 +134,6 @@ class ManifestsManager(object):
     def setManifest(self, manifestHash, manifest):
         self.manifestSection(manifestHash).setManifest(manifestHash, manifest)
 
-    def getManifest(self, manifestHash):
-        return self.manifestSection(manifestHash).getManifest(manifestHash)
-
     def clean(self, maxManifestsSize):
         manifestFileInfos = []
         for filepath in filesBeneath(self._manifestsRootDir):
@@ -1391,7 +1388,7 @@ def processCompileRequest(cache, compiler, args):
 def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
     manifestHash = ManifestsManager.getManifestHash(compiler, cmdLine, sourceFile)
     with cache.lock:
-        manifest = cache.manifestsManager.getManifest(manifestHash)
+        manifest = cache.manifestsManager.manifestSection(manifestHash).getManifest(manifestHash)
         baseDir = os.environ.get('CLCACHE_BASEDIR')
         if baseDir and not baseDir.endswith(os.path.sep):
             baseDir += os.path.sep

--- a/clcache.py
+++ b/clcache.py
@@ -125,9 +125,6 @@ class ManifestsManager(object):
     def manifestSection(self, manifestHash):
         return ManifestSection(os.path.join(self._manifestsRootDir, manifestHash[:2]))
 
-    def setManifest(self, manifestHash, manifest):
-        self.manifestSection(manifestHash).setManifest(manifestHash, manifest)
-
     def clean(self, maxManifestsSize):
         manifestFileInfos = []
         for filepath in filesBeneath(self._manifestsRootDir):
@@ -1230,7 +1227,7 @@ def postprocessHeaderChangedMiss(cache, objectFile, manifest, manifestHash, incl
         if returnCode == 0 and os.path.exists(objectFile):
             addObjectToCache(stats, cache, objectFile, compilerOutput, compilerStderr, cachekey)
             cache.removeObjects(stats, removedItems)
-            cache.manifestsManager.setManifest(manifestHash, manifest)
+            cache.manifestsManager.manifestSection(manifestHash).setManifest(manifestHash, manifest)
 
     return compilerResult
 
@@ -1255,7 +1252,7 @@ def postprocessNoManifestMiss(cache, objectFile, manifestHash, baseDir, sourceFi
         if returnCode == 0 and os.path.exists(objectFile):
             # Store compile output and manifest
             addObjectToCache(stats, cache, objectFile, compilerOutput, compilerStderr, cachekey)
-            cache.manifestsManager.setManifest(manifestHash, manifest)
+            cache.manifestsManager.manifestSection(manifestHash).setManifest(manifestHash, manifest)
 
     return returnCode, compilerOutput, compilerStderr
 

--- a/clcache.py
+++ b/clcache.py
@@ -125,6 +125,12 @@ class ManifestsManager(object):
     def manifestSection(self, manifestHash):
         return ManifestSection(os.path.join(self._manifestsRootDir, manifestHash[:2]))
 
+    def manifestSections(self):
+        for entry in os.listdir(self._manifestsRootDir):
+            path = os.path.join(self._manifestsRootDir, entry)
+            if os.path.isdir(path):
+                yield ManifestSection(path)
+
     def clean(self, maxManifestsSize):
         manifestFileInfos = []
         for filepath in filesBeneath(self._manifestsRootDir):

--- a/clcache.py
+++ b/clcache.py
@@ -125,9 +125,6 @@ class ManifestsManager(object):
     def manifestSection(self, manifestHash):
         return ManifestSection(os.path.join(self._manifestsRootDir, manifestHash[:2]))
 
-    def manifestPath(self, manifestHash):
-        return self.manifestSection(manifestHash).manifestPath(manifestHash)
-
     def setManifest(self, manifestHash, manifest):
         self.manifestSection(manifestHash).setManifest(manifestHash, manifest)
 

--- a/unittests.py
+++ b/unittests.py
@@ -96,7 +96,7 @@ class TestManifestManager(unittest.TestCase):
         manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
         mm = ManifestsManager(manifestsRootDir)
 
-        self.assertEqual(mm.manifestDir("fdde59862785f9f0ad6e661b9b5746b7"), os.path.join(manifestsRootDir, "fd"))
+        self.assertEqual(mm.manifestSection("fdde59862785f9f0ad6e661b9b5746b7").manifestSectionDir, os.path.join(manifestsRootDir, "fd"))
         self.assertEqual(mm.manifestPath("fdde59862785f9f0ad6e661b9b5746b7"),
                          os.path.join(manifestsRootDir, "fd", "fdde59862785f9f0ad6e661b9b5746b7.json"))
 

--- a/unittests.py
+++ b/unittests.py
@@ -152,12 +152,12 @@ class TestManifestManager(unittest.TestCase):
         mm.setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
         mm.setManifest("0623305942d216c165970948424ae7d1", manifest2)
 
-        retrieved1 = mm.getManifest("8a33738d88be7edbacef48e262bbb5bc")
+        retrieved1 = mm.manifestSection("8a33738d88be7edbacef48e262bbb5bc").getManifest("8a33738d88be7edbacef48e262bbb5bc")
         self.assertIsNotNone(retrieved1)
         self.assertEqual(retrieved1.includesContentToObjectMap["fdde59862785f9f0ad6e661b9b5746b7"],
                          "a649723940dc975ebd17167d29a532f8")
 
-        retrieved2 = mm.getManifest("0623305942d216c165970948424ae7d1")
+        retrieved2 = mm.manifestSection("0623305942d216c165970948424ae7d1").getManifest("0623305942d216c165970948424ae7d1")
         self.assertIsNotNone(retrieved2)
         self.assertEqual(retrieved2.includesContentToObjectMap["474e7fc26a592d84dfa7416c10f036c6"],
                          "8771d7ebcf6c8bd57a3d6485f63e3a89")
@@ -166,7 +166,8 @@ class TestManifestManager(unittest.TestCase):
         manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
         mm = ManifestsManager(manifestsRootDir)
 
-        retrieved = mm.getManifest("ffffffffffffffffffffffffffffffff")
+        retrieved = mm.manifestSection("ffffffffffffffffffffffffffffffff") \
+                      .getManifest("ffffffffffffffffffffffffffffffff")
         self.assertIsNone(retrieved)
 
     def testClean(self):

--- a/unittests.py
+++ b/unittests.py
@@ -150,15 +150,18 @@ class TestManifestManager(unittest.TestCase):
             "474e7fc26a592d84dfa7416c10f036c6": "8771d7ebcf6c8bd57a3d6485f63e3a89"
         })
 
-        mm.setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
-        mm.setManifest("0623305942d216c165970948424ae7d1", manifest2)
+        ms1 = mm.manifestSection("8a33738d88be7edbacef48e262bbb5bc")
+        ms2 = mm.manifestSection("0623305942d216c165970948424ae7d1")
 
-        retrieved1 = mm.manifestSection("8a33738d88be7edbacef48e262bbb5bc").getManifest("8a33738d88be7edbacef48e262bbb5bc")
+        ms1.setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
+        ms2.setManifest("0623305942d216c165970948424ae7d1", manifest2)
+
+        retrieved1 = ms1.getManifest("8a33738d88be7edbacef48e262bbb5bc")
         self.assertIsNotNone(retrieved1)
         self.assertEqual(retrieved1.includesContentToObjectMap["fdde59862785f9f0ad6e661b9b5746b7"],
                          "a649723940dc975ebd17167d29a532f8")
 
-        retrieved2 = mm.manifestSection("0623305942d216c165970948424ae7d1").getManifest("0623305942d216c165970948424ae7d1")
+        retrieved2 = ms2.getManifest("0623305942d216c165970948424ae7d1")
         self.assertIsNotNone(retrieved2)
         self.assertEqual(retrieved2.includesContentToObjectMap["474e7fc26a592d84dfa7416c10f036c6"],
                          "8771d7ebcf6c8bd57a3d6485f63e3a89")
@@ -183,8 +186,10 @@ class TestManifestManager(unittest.TestCase):
         manifest2 = Manifest([r'somepath\myinclude.h', 'moreincludes.h'], {
             "474e7fc26a592d84dfa7416c10f036c6": "8771d7ebcf6c8bd57a3d6485f63e3a89"
         })
-        mm.setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
-        mm.setManifest("0623305942d216c165970948424ae7d1", manifest2)
+        mm.manifestSection("8a33738d88be7edbacef48e262bbb5bc") \
+          .setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
+        mm.manifestSection("0623305942d216c165970948424ae7d1") \
+          .setManifest("0623305942d216c165970948424ae7d1", manifest2)
 
         mm.clean(240)
         # Only one of those manifests can be left

--- a/unittests.py
+++ b/unittests.py
@@ -95,9 +95,10 @@ class TestManifestManager(unittest.TestCase):
     def testPaths(self):
         manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
         mm = ManifestsManager(manifestsRootDir)
+        ms = mm.manifestSection("fdde59862785f9f0ad6e661b9b5746b7")
 
-        self.assertEqual(mm.manifestSection("fdde59862785f9f0ad6e661b9b5746b7").manifestSectionDir, os.path.join(manifestsRootDir, "fd"))
-        self.assertEqual(mm.manifestPath("fdde59862785f9f0ad6e661b9b5746b7"),
+        self.assertEqual(ms.manifestSectionDir, os.path.join(manifestsRootDir, "fd"))
+        self.assertEqual(ms.manifestPath("fdde59862785f9f0ad6e661b9b5746b7"),
                          os.path.join(manifestsRootDir, "fd", "fdde59862785f9f0ad6e661b9b5746b7.json"))
 
     def testIncludesContentHash(self):


### PR DESCRIPTION
This PR introduces the notion of 'manifest sections'. The `ManifestsManager` class provides access to one of up to 256 `ManifestSection` objects, each of which representing one of the up to 256 subdirectories of the `manifests` directory. A manifest section is then the object which provides access to individual manifests.

The PR makes the code base use `ManifestSection` objects throughout. The purpose of this is to make it easy to introduce section-specific locks in a future commit, by adding a single `with manifestSection.lock:` in the `processDirect` function and then having the rest of the code operate on that single locked section, instead of locking the entire cache.

The PR should not introduce any functional change, it's just preparation for adding more fine-grained locking in order to address #160 .

@webmaster128 can you have a look? The `ManifestsManager` is kinda your baby, I'd rather not botch it right away.