### PR TITLE
Optimized cache misses in direct mode if CLCACHE_BASEDIR is set

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -217,11 +217,13 @@ class ObjectCacheLock(object):
 
 
 class ObjectCache(object):
-    def __init__(self):
-        try:
-            self.dir = os.environ["CLCACHE_DIR"]
-        except KeyError:
-            self.dir = os.path.join(os.path.expanduser("~"), "clcache")
+    def __init__(self, cacheDirectory=None):
+        self.dir = cacheDirectory
+        if not self.dir:
+            try:
+                self.dir = os.environ["CLCACHE_DIR"]
+            except KeyError:
+                self.dir = os.path.join(os.path.expanduser("~"), "clcache")
 
         manifestsRootDir = os.path.join(self.dir, "manifests")
         ensureDirectoryExists(manifestsRootDir)

--- a/tests/integrationtests/basedir/constants.h
+++ b/tests/integrationtests/basedir/constants.h
@@ -1,0 +1,8 @@
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#include <string>
+
+std::string databaseId() { return "opm"; }
+
+#endif // !defined(CONSTANTS_H)

--- a/tests/integrationtests/basedir/main.cpp
+++ b/tests/integrationtests/basedir/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include "constants.h"
+
+int main()
+{
+    std::cout << databaseId() << '\n';
+}
+
+

--- a/unittests.py
+++ b/unittests.py
@@ -721,7 +721,6 @@ class TestParseIncludes(unittest.TestCase):
         includesSet, newCompilerOutput = clcache.parseIncludesList(
             sample['CompilerOutput'],
             r'C:\Projects\test\smartsqlite\src\version.cpp',
-            None,
             strip=False)
 
         self.assertEqual(len(includesSet), sample['UniqueIncludesCount'])
@@ -736,7 +735,6 @@ class TestParseIncludes(unittest.TestCase):
         includesSet, newCompilerOutput = clcache.parseIncludesList(
             sample['CompilerOutput'],
             r'C:\Projects\test\smartsqlite\src\version.cpp',
-            None,
             strip=True)
 
         self.assertEqual(len(includesSet), sample['UniqueIncludesCount'])
@@ -752,7 +750,6 @@ class TestParseIncludes(unittest.TestCase):
             includesSet, newCompilerOutput = clcache.parseIncludesList(
                 sample['CompilerOutput'],
                 r"C:\Projects\test\myproject\main.cpp",
-                None,
                 strip=stripIncludes)
 
             self.assertEqual(len(includesSet), sample['UniqueIncludesCount'])
@@ -763,7 +760,6 @@ class TestParseIncludes(unittest.TestCase):
         includesSet, _ = clcache.parseIncludesList(
             sample['CompilerOutput'],
             r"C:\Projects\test\smartsqlite\src\version.cpp",
-            None,
             strip=False)
 
         self.assertEqual(len(includesSet), sample['UniqueIncludesCount'])


### PR DESCRIPTION
In case CLCACHE_BASEDIR was set, the parseIncludesList() function would
automatically make all include paths relocatable by replacing the base
directory with a magic placeholder. In postprocessNoManifestMiss()
however, we would immediately reverse this operation by expanding the
placeholder again.

The only reason why we may want a placeholder is to store relocatable
paths in the Manifest object, so let's do that there and otherwise deal
with full paths.