### PR TITLE
Cache sections

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -299,6 +299,12 @@ class ObjectCache(object):
     def cacheSection(self, key):
         return CacheSection(os.path.join(self.objectsDir, key[:2]))
 
+    def cacheSections(self):
+        for entry in os.listdir(self.objectsDir):
+            path = os.path.join(self.objectsDir, entry)
+            if os.path.isdir(path):
+                yield CacheSection(path)
+
     def clean(self, stats, maximumSize):
         currentSize = stats.currentCacheSize()
         if currentSize < maximumSize:

--- a/clcache.py
+++ b/clcache.py
@@ -227,6 +227,11 @@ class ObjectCacheLock(object):
         self._acquired = False
 
 
+class CacheSection(object):
+    def __init__(self, cacheSectionDir):
+        self.cacheSectionDir = cacheSectionDir
+
+
 class ObjectCache(object):
     def __init__(self, cacheDirectory=None):
         self.dir = cacheDirectory

--- a/clcache.py
+++ b/clcache.py
@@ -322,16 +322,14 @@ class ObjectCache(object):
         currentSizeManifests = self.manifestsManager.clean(effectiveMaximumSizeManifests)
 
         # Clean objects
-        objects = [os.path.join(root, "object")
-                   for root, _, files in WALK(self.objectsDir)
-                   if "object" in files]
-
         objectInfos = []
-        for o in objects:
-            try:
-                objectInfos.append((os.stat(o), o))
-            except OSError:
-                pass
+        for section in self.cacheSections():
+            objects = (section.cachedObjectName(key) for key in section.cacheEntries())
+            for o in objects:
+                try:
+                    objectInfos.append((os.stat(o), o))
+                except OSError:
+                    pass
 
         objectInfos.sort(key=lambda t: t[0].st_atime)
 

--- a/clcache.py
+++ b/clcache.py
@@ -387,12 +387,6 @@ class ObjectCache(object):
     def _cacheEntryDir(self, key):
         return self.cacheSection(key).cacheEntryDir(key)
 
-    def _cachedCompilerOutputName(self, key):
-        return self.cacheSection(key).cachedCompilerOutputName(key)
-
-    def _cachedCompilerStderrName(self, key):
-        return self.cacheSection(key).cachedCompilerStderrName(key)
-
     @staticmethod
     def _normalizedCommandLine(cmdline):
         # Remove all arguments from the command line which only influence the

--- a/clcache.py
+++ b/clcache.py
@@ -234,6 +234,12 @@ class CacheSection(object):
     def cacheEntryDir(self, key):
         return os.path.join(self.cacheSectionDir, key)
 
+    def cacheEntries(self):
+        for entry in os.listdir(self.cacheSectionDir):
+            path = os.path.join(self.cacheSectionDir, entry)
+            if os.path.isdir(path):
+                yield entry
+
     def cachedObjectName(self, key):
         return os.path.join(self.cacheEntryDir(key), "object")
 

--- a/clcache.py
+++ b/clcache.py
@@ -254,6 +254,9 @@ class ObjectCache(object):
     def cacheDirectory(self):
         return self.dir
 
+    def cacheSection(self, key):
+        return CacheSection(os.path.join(self.objectsDir, key[:2]))
+
     def clean(self, stats, maximumSize):
         currentSize = stats.currentCacheSize()
         if currentSize < maximumSize:

--- a/clcache.py
+++ b/clcache.py
@@ -339,7 +339,7 @@ class ObjectCache(object):
 
     def removeObjects(self, stats, removedObjects):
         for o in removedObjects:
-            dirPath = self._cacheEntryDir(o)
+            dirPath = self.cacheSection(o).cacheEntryDir(o)
             if not os.path.exists(dirPath):
                 continue  # May be if object already evicted.
             objectPath = os.path.join(dirPath, "object")
@@ -383,9 +383,6 @@ class ObjectCache(object):
         # collisions when different source files use the same
         # set of includes.
         return ObjectCache.getHash(manifestHash + includesContentHash)
-
-    def _cacheEntryDir(self, key):
-        return self.cacheSection(key).cacheEntryDir(key)
 
     @staticmethod
     def _normalizedCommandLine(cmdline):


### PR DESCRIPTION
This PR introduces the notion of `CacheObjects`, objects which represent a single of the up to 256 different subdirectories of the `objects` directory. By making the code work with individual code sections, we get closer to locking just those sections which are being interacted with, improving the concurrency behaviour to address #160 .

After merging this PR, the next step would be to store the statistics (at least the cache hits) per section.

Once that is done, we should be able to implement finer-grained locking by just locking the manifest and cache sections we need.