### PR TITLE
Added wrapper for Popen for run under Visual Studio.

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -90,6 +90,14 @@ def normalizeBaseDir(baseDir):
         return None
 
 
+def popen(*args, **kwargs):
+    if 'env' not in 'kwargs':
+        kwargs['env'] = os.environ.copy()
+    if 'VS_UNICODE_OUTPUT' in kwargs['env']:
+        del kwargs['env']['VS_UNICODE_OUTPUT']
+    return Popen(*args, **kwargs)
+
+
 class CacheLockException(Exception):
     pass
 
@@ -326,7 +334,7 @@ class CompilerArtifactsRepository(object):
     def computeCompilerArtifactsKey(compilerBinary, commandLine):
         ppcmd = [compilerBinary, "/EP"]
         ppcmd += [arg for arg in commandLine if arg not in ("-c", "/c")]
-        preprocessor = Popen(ppcmd, stdout=PIPE, stderr=PIPE)
+        preprocessor = popen(ppcmd, stdout=PIPE, stderr=PIPE)
         (preprocessedSourceCode, ppStderrBinary) = preprocessor.communicate()
 
         if preprocessor.returncode != 0:
@@ -1051,7 +1059,7 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False):
     stdout = ''
     stderr = ''
     if captureOutput:
-        compilerProcess = Popen(realCmdline, stdout=PIPE, stderr=PIPE)
+        compilerProcess = popen(realCmdline, stdout=PIPE, stderr=PIPE)
         stdoutBinary, stderrBinary = compilerProcess.communicate()
         stdout = stdoutBinary.decode(CL_DEFAULT_CODEC)
         stderr = stderrBinary.decode(CL_DEFAULT_CODEC)


### PR DESCRIPTION
I found clcache not working properly under Visual Studio.
When I change header file and try to build I get same hash for source so get same object from cache. It happens because information about includes doesn't saved in manifests. Moreover I see messages from cl.exe calls with /showIncludes in Visual Studio console.
The reason is Visual Studio defines VS_UNICODE_OUTPUT environment variables which affects cl.exe (more at https://blogs.msdn.microsoft.com/freik/2006/04/05/how-to-get-cl-exe-proxy-filters-like-stlfilt-working-under-vs2005/).
I wrote simple wrapper for Popen which unset VS_UNICODE_OUTPUT if it was set.