### PR TITLE
Compilerartifacts

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -274,6 +274,11 @@ class CompilerArtifactsSection(object):
             with open(self.cachedCompilerStderrName(key), 'wb') as f:
                 f.write(compilerStderr.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
 
+    def getEntry(self, key):
+        if not os.path.exists(self.cacheEntryDir(key)):
+            return None
+        return CompilerArtifacts(self.cachedObjectName(key), self.cachedCompilerOutput(key), self.cachedCompilerStderr(key))
+
 
 class CompilerArtifactsRepository(object):
     def __init__(self, compilerArtifactsRootDir):

--- a/clcache.py
+++ b/clcache.py
@@ -251,7 +251,7 @@ class CompilerArtifactsSection(object):
         return os.path.join(self.cacheEntryDir(key), "stderr.txt")
 
     def hasEntry(self, key):
-        return os.path.exists(self.cachedObjectName(key)) or os.path.exists(self.cachedCompilerOutputName(key))
+        return os.path.exists(self.cacheEntryDir(key))
 
     def setEntry(self, key, objectFileName, compilerOutput, compilerStderr):
         ensureDirectoryExists(self.cacheEntryDir(key))

--- a/clcache.py
+++ b/clcache.py
@@ -1280,11 +1280,10 @@ def processCacheHit(cache, objectFile, cachekey):
     if os.path.exists(objectFile):
         os.remove(objectFile)
     section = cache.compilerArtifactsRepository.section(cachekey)
-    copyOrLink(section.cachedObjectName(cachekey), objectFile)
-    compilerOutput = section.cachedCompilerOutput(cachekey)
-    compilerStderr = section.cachedCompilerStderr(cachekey)
+    cachedArtifacts = section.getEntry(cachekey)
+    copyOrLink(cachedArtifacts.objectFilePath, objectFile)
     printTraceStatement("Finished. Exit code 0")
-    return 0, compilerOutput, compilerStderr
+    return 0, cachedArtifacts.compilerStdout, cachedArtifacts.compilerStderr
 
 
 def postprocessObjectEvicted(cache, objectFile, cachekey, compilerResult):

--- a/clcache.py
+++ b/clcache.py
@@ -256,8 +256,7 @@ class CompilerArtifactsSection(object):
             self._setCachedCompilerConsoleOutput(key, 'stderr.txt', compilerStderr)
 
     def getEntry(self, key):
-        if not os.path.exists(self.cacheEntryDir(key)):
-            return None
+        assert self.hasEntry(key)
         return CompilerArtifacts(
             self.cachedObjectName(key),
             self._getCachedCompilerConsoleOutput(key, 'output.txt'),

--- a/clcache.py
+++ b/clcache.py
@@ -244,17 +244,6 @@ class CompilerArtifactsSection(object):
     def cachedObjectName(self, key):
         return os.path.join(self.cacheEntryDir(key), "object")
 
-    def cachedCompilerOutput(self, key):
-        with open(self.cachedCompilerOutputName(key), 'rb') as f:
-            return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
-
-    def cachedCompilerStderr(self, key):
-        fileName = self.cachedCompilerStderrName(key)
-        if os.path.exists(fileName):
-            with open(fileName, 'rb') as f:
-                return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
-        return ''
-
     def cachedCompilerOutputName(self, key):
         return os.path.join(self.cacheEntryDir(key), "output.txt")
 
@@ -277,7 +266,19 @@ class CompilerArtifactsSection(object):
     def getEntry(self, key):
         if not os.path.exists(self.cacheEntryDir(key)):
             return None
-        return CompilerArtifacts(self.cachedObjectName(key), self.cachedCompilerOutput(key), self.cachedCompilerStderr(key))
+        return CompilerArtifacts(
+            self.cachedObjectName(key),
+            self._getCachedCompilerConsoleOutput(key, 'output.txt'),
+            self._getCachedCompilerConsoleOutput(key, 'stderr.txt')
+            )
+
+    def _getCachedCompilerConsoleOutput(self, key, fileName):
+        try:
+            outputFilePath = os.path.join(self.cacheEntryDir(key), fileName)
+            with open(outputFilePath, 'rb') as f:
+                return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
+        except IOError:
+            return ''
 
 
 class CompilerArtifactsRepository(object):

--- a/clcache.py
+++ b/clcache.py
@@ -56,6 +56,7 @@ BASEDIR_REPLACEMENT = '?'
 #   value: key in the cache, under which the object file is stored
 Manifest = namedtuple('Manifest', ['includeFiles', 'includesContentToObjectMap'])
 
+CompilerArtifacts = namedtuple('CompilerArtifacts', ['objectFilePath', 'compilerStdout', 'compilerStderr'])
 
 def printBinary(stream, rawData):
     stream.buffer.write(rawData)

--- a/clcache.py
+++ b/clcache.py
@@ -244,12 +244,6 @@ class CompilerArtifactsSection(object):
     def cachedObjectName(self, key):
         return os.path.join(self.cacheEntryDir(key), "object")
 
-    def cachedCompilerOutputName(self, key):
-        return os.path.join(self.cacheEntryDir(key), "output.txt")
-
-    def cachedCompilerStderrName(self, key):
-        return os.path.join(self.cacheEntryDir(key), "stderr.txt")
-
     def hasEntry(self, key):
         return os.path.exists(self.cacheEntryDir(key))
 
@@ -257,11 +251,9 @@ class CompilerArtifactsSection(object):
         ensureDirectoryExists(self.cacheEntryDir(key))
         if objectFileName is not None:
             copyOrLink(objectFileName, self.cachedObjectName(key))
-        with open(self.cachedCompilerOutputName(key), 'wb') as f:
-            f.write(compilerOutput.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
+        self._setCachedCompilerConsoleOutput(key, 'output.txt', compilerOutput)
         if compilerStderr != '':
-            with open(self.cachedCompilerStderrName(key), 'wb') as f:
-                f.write(compilerStderr.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
+            self._setCachedCompilerConsoleOutput(key, 'stderr.txt', compilerStderr)
 
     def getEntry(self, key):
         if not os.path.exists(self.cacheEntryDir(key)):
@@ -279,6 +271,11 @@ class CompilerArtifactsSection(object):
                 return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
         except IOError:
             return ''
+
+    def _setCachedCompilerConsoleOutput(self, key, fileName, output):
+        outputFilePath = os.path.join(self.cacheEntryDir(key), fileName)
+        with open(outputFilePath, 'wb') as f:
+            f.write(output.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
 
 
 class CompilerArtifactsRepository(object):

--- a/clcache.py
+++ b/clcache.py
@@ -56,7 +56,7 @@ BASEDIR_REPLACEMENT = '?'
 #   value: key in the cache, under which the object file is stored
 Manifest = namedtuple('Manifest', ['includeFiles', 'includesContentToObjectMap'])
 
-CompilerArtifacts = namedtuple('CompilerArtifacts', ['objectFilePath', 'compilerStdout', 'compilerStderr'])
+CompilerArtifacts = namedtuple('CompilerArtifacts', ['objectFilePath', 'stdout', 'stderr'])
 
 def printBinary(stream, rawData):
     stream.buffer.write(rawData)
@@ -251,9 +251,9 @@ class CompilerArtifactsSection(object):
         ensureDirectoryExists(self.cacheEntryDir(key))
         if artifacts.objectFilePath is not None:
             copyOrLink(artifacts.objectFilePath, self.cachedObjectName(key))
-        self._setCachedCompilerConsoleOutput(key, 'output.txt', artifacts.compilerStdout)
-        if artifacts.compilerStderr != '':
-            self._setCachedCompilerConsoleOutput(key, 'stderr.txt', artifacts.compilerStderr)
+        self._setCachedCompilerConsoleOutput(key, 'output.txt', artifacts.stdout)
+        if artifacts.stderr != '':
+            self._setCachedCompilerConsoleOutput(key, 'stderr.txt', artifacts.stderr)
 
     def getEntry(self, key):
         assert self.hasEntry(key)
@@ -1280,7 +1280,7 @@ def processCacheHit(cache, objectFile, cachekey):
     cachedArtifacts = section.getEntry(cachekey)
     copyOrLink(cachedArtifacts.objectFilePath, objectFile)
     printTraceStatement("Finished. Exit code 0")
-    return 0, cachedArtifacts.compilerStdout, cachedArtifacts.compilerStderr
+    return 0, cachedArtifacts.stdout, cachedArtifacts.stderr
 
 
 def postprocessObjectEvicted(cache, objectFile, cachekey, compilerResult):


### PR DESCRIPTION
This introduces (and makes use of) a new `CompilerArtifacts` type which is now returned (and expected) in `CompilerArtifactsSection.setEntry` and `CompilerArtifactsSection.getEntry`. I think this the last piece of implement the naming discussed in #187 .