### PR TITLE
Drop support for the CL environment variable in jobCount()

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -140,6 +140,12 @@ CLCACHE_OBJECT_CACHE_TIMEOUT_MS::
     getting ObjectCacheLockExceptions with return code 258 (which is the
     WAIT_TIMEOUT return code).
 
+Known limitations
+~~~~~~~~~~~~~~~~~
+
+* https://msdn.microsoft.com/en-us/library/kezkeayy.aspx[CL and +_CL_+] environment
+  variables are not supported.
+
 How clcache works
 ~~~~~~~~~~~~~~~~~
 

--- a/clcache.py
+++ b/clcache.py
@@ -1088,19 +1088,9 @@ def waitForAnyProcess(procs):
 
 
 # Returns the amount of jobs which should be run in parallel when
-# invoked in batch mode.
-#
-# The '/MP' option determines this, which may be set in cmdLine or
-# in the CL environment variable.
+# invoked in batch mode as determined by the /MP argument
 def jobCount(cmdLine):
-    switches = []
-
-    if 'CL' in os.environ:
-        switches.extend(os.environ['CL'].split(' '))
-
-    switches.extend(cmdLine)
-
-    mpSwitches = [switch for switch in switches if re.search(r'^/MP(\d+)?$', switch) is not None]
+    mpSwitches = [arg for arg in cmdLine if re.match(r'^/MP(\d+)?$', arg)]
     if len(mpSwitches) == 0:
         return 1
 


### PR DESCRIPTION
`CL` and `_CL_` are never respected or tested in the entire project, making
it basically impossible to rely on them. This adds a note on that.

If someone wants to get `CL` or `_CL_` support, it has to be implemented in
a much more general way.