### PR TITLE
Fixed /MP causing a lot of cache misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ clcache changelog
 
 ## Upcoming release
 
- * Nothing yet.
+ * Bugfix: /MP no longer causes a greatly reduced cache hit rate.
 
 ## clcache 3.2.0 (2016-07-28)
 

--- a/clcache.py
+++ b/clcache.py
@@ -173,7 +173,11 @@ class ManifestRepository(object):
 
         # NOTE: We intentionally do not normalize command line to include
         # preprocessor options. In direct mode we do not perform
-        # preprocessing before cache lookup, so all parameters are important
+        # preprocessing before cache lookup, so all parameters are important.
+        # One of the few exceptions to this rule is the /MP switch, which only
+        # defines how many compiler processes are running simultaneusly.
+        commandLine = [arg for arg in commandLine if not arg.startswith("/MP")]
+
         additionalData = "{}|{}|{}".format(
             compilerHash, commandLine, ManifestRepository.MANIFEST_FILE_FORMAT_VERSION)
         return getFileHash(sourceFile, additionalData)
@@ -356,6 +360,11 @@ class CompilerArtifactsRepository(object):
         # want two invocations which are identical except for the output file
         # name to be treated differently.
         argsToStrip += ("Fo",)
+
+        # Also strip the switch for specifying the number of parallel compiler
+        # processes to use (when specifying multiple source files on the
+        # command line).
+        argsToStrip += ("MP",)
 
         return [arg for arg in cmdline
                 if not (arg[0] in "/-" and arg[1:].startswith(argsToStrip))]


### PR DESCRIPTION
I noticed that when compiling two source files individually and then
compiling both of them in one go while specifying /MP would not cause
any cache hits. It turns out that this is because the /MP switch
contributes to the hashed command line, and when reinvoking itself
recursively, clcache does not strip the /MP switch for the individual
child processes.

Let's fix this by stripping the flag in both direct as well as indirect
mode. I think stripping this flag even in direct mode should be safe
since it doesn't influence the preprocessor. I think that technically,
we could strip a couple more flags in direct mode, though we need to
keep all those relevant to the preprocessor.