### PR TITLE
Adding a simple 'performance test'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,7 @@ build_script:
   - pylint --rcfile=.pylintrc clcache.py
   - pylint --rcfile=.pylintrc unittests.py
   - pylint --rcfile=.pylintrc integrationtests.py
+  - pylint --rcfile=.pylintrc performancetests.py
 
 test_script:
   # Run test files via py.test and generate JUnit XML. Then push test results

--- a/performancetests.py
+++ b/performancetests.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# This file is part of the clcache project.
+#
+# The contents of this file are subject to the BSD 3-Clause License, the
+# full text of which is available in the accompanying LICENSE file at the
+# root directory of this project.
+#
+# In Python unittests are always members, not functions. Silence lint in this file.
+# pylint: disable=no-self-use
+#
+from multiprocessing import cpu_count
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import timeit
+import unittest
+
+import clcache
+
+PYTHON_BINARY = sys.executable
+CLCACHE_SCRIPT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "clcache.py")
+ASSETS_DIR = os.path.join("tests", "performancetests")
+
+if "CLCACHE_CMD" in os.environ:
+    CLCACHE_CMD = os.environ['CLCACHE_CMD'].split()
+else:
+    CLCACHE_CMD = [PYTHON_BINARY, CLCACHE_SCRIPT]
+
+def takeTime(code):
+    start = timeit.default_timer()
+    code()
+    return timeit.default_timer() - start
+
+class TestConcurrency(unittest.TestCase):
+    NUM_SOURCE_FILES = 30
+
+    def testConcurrentHitsScaling(self):
+        for i in range(1, TestConcurrency.NUM_SOURCE_FILES):
+            shutil.copyfile(
+                os.path.join(ASSETS_DIR, 'concurrency', 'file01.cpp'),
+                os.path.join(ASSETS_DIR, 'concurrency', 'file{:02d}.cpp'.format(i+1))
+            )
+
+        sources = []
+        for i in range(1, TestConcurrency.NUM_SOURCE_FILES+1):
+            sources.append(os.path.join(ASSETS_DIR, 'concurrency', 'file{:02d}.cpp'.format(i)))
+
+        with tempfile.TemporaryDirectory() as tempDir:
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+
+            cache = clcache.Cache(tempDir)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 0)
+                self.assertEqual(stats.numCacheEntries(), 0)
+
+            # Populate cache
+            cmd = CLCACHE_CMD + ['/nologo', '/EHsc', '/c'] + sources
+            coldCacheSequential = takeTime(lambda: subprocess.check_call(cmd, env=customEnv))
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), len(sources))
+                self.assertEqual(stats.numCacheEntries(), len(sources))
+
+            # Compile one-by-one, measuring the time.
+            cmd = CLCACHE_CMD + ['/nologo', '/EHsc', '/c'] + sources
+            hotCacheSequential = takeTime(lambda: subprocess.check_call(cmd, env=customEnv))
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), len(sources))
+                self.assertEqual(stats.numCacheMisses(), len(sources))
+                self.assertEqual(stats.numCacheEntries(), len(sources))
+
+            # Recompile with many concurrent processes, measuring time
+            cmd = CLCACHE_CMD + ['/nologo', '/EHsc', '/c', '/MP{}'.format(cpu_count())] + sources
+            hotCacheConcurrent = takeTime(lambda: subprocess.check_call(cmd, env=customEnv))
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), len(sources) * 2)
+                self.assertEqual(stats.numCacheMisses(), len(sources))
+                self.assertEqual(stats.numCacheEntries(), len(sources))
+
+            print("Compiling {} source files sequentially, cold cache: {} seconds"
+                  .format(len(sources), coldCacheSequential))
+            print("Compiling {} source files sequentially, hot cache: {} seconds"
+                  .format(len(sources), hotCacheSequential))
+            print("Compiling {} source files concurrently via /MP{}, hot cache: {} seconds"
+                  .format(len(sources), cpu_count(), hotCacheConcurrent))
+
+
+if __name__ == '__main__':
+    unittest.TestCase.longMessage = True
+    unittest.main()

--- a/tests/performancetests/concurrency/file01.cpp
+++ b/tests/performancetests/concurrency/file01.cpp
@@ -1,0 +1,8 @@
+// Include a couple of headers so that the compiler has some work to do
+#include <windows.h>
+#include <iostream>
+
+static void f()
+{
+}
+


### PR DESCRIPTION
This test benchmarks compiling N equal source files (the exact number is
configurable via a NUM_SOURCE_FILES constant in the test code)
sequentially with a cold cache, then with a hot cache (i.e. 100% hit
rate) and then with a hot cache and concurrent compilation (which should
be even faster assuming that there is no global locking).

I'm not sure whether it's possible to actually verify some timing values
automatically, these timings depend very much on the particlar machine
and system load. So for now, I just verify that the cache contents
change as expected and then print some timings at the end.

We do however ask Appveyor to run pylint on the test code automatically
to help ensuring it's in a tidy state.