### PR TITLE
Calls to non-existing includes should force a cache miss to display compiler error

### DIFF
--- a/unittests.py
+++ b/unittests.py
@@ -22,6 +22,7 @@ from clcache import (
     Manifest,
     ManifestRepository,
     Statistics,
+    getFileHash
 )
 from clcache import (
     AnalysisError,
@@ -281,6 +282,15 @@ class TestManifestRepository(unittest.TestCase):
         self.assertEqual(cleaningResultSize, 0)
         self.assertEqual(self._getDirectorySize(self.manifestsRootDir), 0)
 
+    def testNonExistingInclude(self):
+        try:
+            self.mm.getIncludesContentHashForFiles(["include/removedInclude.h"])
+        except Exception as e:
+            self.fail('Failed to handle non-existing includes: {0} {1} '.format(type(e).__name__,e))
+
+class TestGlobalFunctions(unittest.TestCase):
+    def testgetFileHash(self):
+        self.assertEqual(getFileHash("nonexisting.h"), None)
 
 class TestCompilerArtifactsRepository(unittest.TestCase):
     def testPaths(self):

--- a/unittests.py
+++ b/unittests.py
@@ -175,14 +175,16 @@ class TestManifestRepository(unittest.TestCase):
 
         return size
 
-    def testPaths(self):
-        manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
-        mm = ManifestRepository(manifestsRootDir)
-        ms = mm.section("fdde59862785f9f0ad6e661b9b5746b7")
+    def setUp(self):
+        self.manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
+        self.mm = ManifestRepository(self.manifestsRootDir)
 
-        self.assertEqual(ms.manifestSectionDir, os.path.join(manifestsRootDir, "fd"))
+    def testPaths(self):
+        ms = self.mm.section("fdde59862785f9f0ad6e661b9b5746b7")
+
+        self.assertEqual(ms.manifestSectionDir, os.path.join(self.manifestsRootDir, "fd"))
         self.assertEqual(ms.manifestPath("fdde59862785f9f0ad6e661b9b5746b7"),
-                         os.path.join(manifestsRootDir, "fd", "fdde59862785f9f0ad6e661b9b5746b7.json"))
+                         os.path.join(self.manifestsRootDir, "fd", "fdde59862785f9f0ad6e661b9b5746b7.json"))
 
     def testIncludesContentHash(self):
         self.assertEqual(
@@ -223,9 +225,6 @@ class TestManifestRepository(unittest.TestCase):
         )
 
     def testStoreAndGetManifest(self):
-        manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
-        mm = ManifestRepository(manifestsRootDir)
-
         manifest1 = Manifest([r'somepath\myinclude.h'], {
             "fdde59862785f9f0ad6e661b9b5746b7": "a649723940dc975ebd17167d29a532f8"
         })
@@ -233,8 +232,8 @@ class TestManifestRepository(unittest.TestCase):
             "474e7fc26a592d84dfa7416c10f036c6": "8771d7ebcf6c8bd57a3d6485f63e3a89"
         })
 
-        ms1 = mm.section("8a33738d88be7edbacef48e262bbb5bc")
-        ms2 = mm.section("0623305942d216c165970948424ae7d1")
+        ms1 = self.mm.section("8a33738d88be7edbacef48e262bbb5bc")
+        ms2 = self.mm.section("0623305942d216c165970948424ae7d1")
 
         ms1.setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
         ms2.setManifest("0623305942d216c165970948424ae7d1", manifest2)
@@ -250,16 +249,10 @@ class TestManifestRepository(unittest.TestCase):
                          "8771d7ebcf6c8bd57a3d6485f63e3a89")
 
     def testNonExistingManifest(self):
-        manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
-        mm = ManifestRepository(manifestsRootDir)
-
-        retrieved = mm.section("ffffffffffffffffffffffffffffffff").getManifest("ffffffffffffffffffffffffffffffff")
+        retrieved = self.mm.section("ffffffffffffffffffffffffffffffff").getManifest("ffffffffffffffffffffffffffffffff")
         self.assertIsNone(retrieved)
 
     def testClean(self):
-        manifestsRootDir = os.path.join(ASSETS_DIR, "manifests")
-        mm = ManifestRepository(manifestsRootDir)
-
         # Size in (120, 240] bytes
         manifest1 = Manifest([r'somepath\myinclude.h'], {
             "fdde59862785f9f0ad6e661b9b5746b7": "a649723940dc975ebd17167d29a532f8"
@@ -268,25 +261,25 @@ class TestManifestRepository(unittest.TestCase):
         manifest2 = Manifest([r'somepath\myinclude.h', 'moreincludes.h'], {
             "474e7fc26a592d84dfa7416c10f036c6": "8771d7ebcf6c8bd57a3d6485f63e3a89"
         })
-        mm.section("8a33738d88be7edbacef48e262bbb5bc").setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
-        mm.section("0623305942d216c165970948424ae7d1").setManifest("0623305942d216c165970948424ae7d1", manifest2)
+        self.mm.section("8a33738d88be7edbacef48e262bbb5bc").setManifest("8a33738d88be7edbacef48e262bbb5bc", manifest1)
+        self.mm.section("0623305942d216c165970948424ae7d1").setManifest("0623305942d216c165970948424ae7d1", manifest2)
 
-        cleaningResultSize = mm.clean(240)
+        cleaningResultSize = self.mm.clean(240)
         # Only one of those manifests can be left
         self.assertLessEqual(cleaningResultSize, 240)
-        self.assertLessEqual(self._getDirectorySize(manifestsRootDir), 240)
+        self.assertLessEqual(self._getDirectorySize(self.manifestsRootDir), 240)
 
-        cleaningResultSize = mm.clean(240)
+        cleaningResultSize = self.mm.clean(240)
         # The one remaining is remains alive
         self.assertLessEqual(cleaningResultSize, 240)
         self.assertGreaterEqual(cleaningResultSize, 120)
-        self.assertLessEqual(self._getDirectorySize(manifestsRootDir), 240)
-        self.assertGreaterEqual(self._getDirectorySize(manifestsRootDir), 120)
+        self.assertLessEqual(self._getDirectorySize(self.manifestsRootDir), 240)
+        self.assertGreaterEqual(self._getDirectorySize(self.manifestsRootDir), 120)
 
-        cleaningResultSize = mm.clean(0)
+        cleaningResultSize = self.mm.clean(0)
         # All manifest are gone
         self.assertEqual(cleaningResultSize, 0)
-        self.assertEqual(self._getDirectorySize(manifestsRootDir), 0)
+        self.assertEqual(self._getDirectorySize(self.manifestsRootDir), 0)
 
 
 class TestCompilerArtifactsRepository(unittest.TestCase):


### PR DESCRIPTION
At the moment clcache will fail when parsing a non-existing header to generate `includesContentHash` for `ManifestRepository.getIncludesContentHashForFiles(listOfIncludes)` with a non-existing include in `listOfincludes`
>          Traceback (most recent call last):
           File "clcache.py", line 1518, in <module>
           File "clcache.py", line 1409, in main
           File "clcache.py", line 1439, in processCompileRequest
           File "clcache.py", line 1476, in processDirect
           File "clcache.py", line 188, in getIncludesContentHashForFiles
           File "clcache.py", line 188, in <listcomp>
           File "clcache.py", line 688, in getFileHash
         FileNotFoundError: [Errno 2] No such file or directory: 'missing.h'

The proposed is not a elegant solution. I don't see a clever way to raise a ForceCacheMissException which could be handled. Please feel free adapt as you wish.