### PR TITLE
Json dumping is twice faster now

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -118,7 +118,7 @@ class ManifestSection(object):
         ensureDirectoryExists(self.manifestSectionDir)
         with open(self.manifestPath(manifestHash), 'w') as outFile:
             # Converting namedtuple to JSON via OrderedDict preserves key names and keys order
-            json.dump(manifest._asdict(), outFile, indent=2)
+            json.dump(manifest._asdict(), outFile)
 
     def getManifest(self, manifestHash):
         fileName = self.manifestPath(manifestHash)
@@ -445,7 +445,7 @@ class PersistentJSONDict(object):
     def save(self):
         if self._dirty:
             with open(self._fileName, 'w') as f:
-                json.dump(self._dict, f, sort_keys=True, indent=4)
+                json.dump(self._dict, f)
 
     def __setitem__(self, key, value):
         self._dict[key] = value


### PR DESCRIPTION
I wrote small script to test simple `json.dump` vs `json.dump` with nice print:
```python
import json
import timeit

iterations=10000
data = """{"CacheEntries": 0, "CacheHits": 1, "CacheMisses": 4, "CacheSize": 0, "CallsForExternalDebugInfo": 1, "CallsForLinking": 1, "CallsForPreprocessing": 1,"CallsWithInvalidArgument": 1, "CallsWithMultipleSourceFiles": 1, "CallsWithPch": 1, "CallsWithoutSourceFile": 1, "EvictedMisses": 1, "HeaderChangedMisses": 1,"SourceChangedMisses": 1}"""

print("iterations="+str(iterations))
print("data=",data)

print("Json pretty:", json.__version__)
print(">>",timeit.timeit("x=json.dumps("+data+", sort_keys=True, indent=4)","import json",number=iterations))

print("Json simple:", json.__version__)
print(">>",timeit.timeit("x=json.dumps("+data+")", "import json",number=iterations))
```

Results:
```
iterations=10000
data= {"CacheEntries": 0, "CacheHits": 1, "CacheMisses": 4, "CacheSize": 0, "CallsForExternalDebugInfo": 1, "CallsForLinking": 1, "CallsForPreprocessing": 1,"CallsWithInvalidArgument": 1, "CallsWithMultipleSourceFiles": 1, "CallsWithPch": 1, "CallsWithoutSourceFile": 1, "EvictedMisses": 1, "HeaderChangedMisses": 1,"SourceChangedMisses": 1}
Json pretty: 2.0.9
>> 0.3718637569982093
Json simple: 2.0.9
>> 0.10602316400036216
```

So, without pretty print it's twice/three times faster.