### PR TITLE
Profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ clcache changelog
  * Bugfix: In direct mode, clcache will no longer try to access non-existant
    header files (GH #200, GH #209).
  * Add support for the `CL` and `_CL_` environment variables (GH #196).
+ * Feature: A new `CLCACHE_PROFILE` environment variable is now recognised
+   which can be used to make clcache generate profiling information. The
+   generated data can be processed into a final report using a new
+   `showprofilereport.py` script.
 
 ## clcache 3.2.0 (2016-07-28)
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -139,6 +139,12 @@ CLCACHE_OBJECT_CACHE_TIMEOUT_MS::
     used by the clcache script. You may override this variable if you are
     getting ObjectCacheLockExceptions with return code 258 (which is the
     WAIT_TIMEOUT return code).
+CLCACHE_PROFILE::
+    If this variable is set, clcache will generate profiling information about
+    how the runtime is spent in the clcache code. For each invocation, clcache
+    will generate a file with a name similiar to 'clcache-<hashsum>.prof'. You
+    can aggregate these files and generate a report by running the
+    'showprofilereport.py' script.
 
 Known limitations
 ~~~~~~~~~~~~~~~~~

--- a/clcache.py
+++ b/clcache.py
@@ -1581,7 +1581,7 @@ def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
 
 if __name__ == '__main__':
     if 'CLCACHE_PROFILE' in os.environ:
-        invocationHash = getStringHash(','.join(sys.argv))
-        cProfile.run('main()', filename='clcache-{}.prof'.format(invocationHash))
+        INVOCATION_HASH = getStringHash(','.join(sys.argv))
+        cProfile.run('main()', filename='clcache-{}.prof'.format(INVOCATION_HASH))
     else:
         sys.exit(main())

--- a/clcache.py
+++ b/clcache.py
@@ -7,6 +7,7 @@
 # root directory of this project.
 #
 from ctypes import windll, wintypes
+import cProfile
 import codecs
 from collections import defaultdict, namedtuple
 import errno
@@ -1579,4 +1580,8 @@ def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
     return returnCode, compilerStdout, compilerStderr
 
 if __name__ == '__main__':
-    sys.exit(main())
+    if 'CLCACHE_PROFILE' in os.environ:
+        invocationHash = getStringHash(','.join(sys.argv))
+        cProfile.run('main()', filename='clcache-{}.prof'.format(invocationHash))
+    else:
+        sys.exit(main())

--- a/showprofilereport.py
+++ b/showprofilereport.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+#
+# This file is part of the clcache project.
+#
+# The contents of this file are subject to the BSD 3-Clause License, the
+# full text of which is available in the accompanying LICENSE file at the
+# root directory of this project.
+#
+import os
+import fnmatch
+import pstats
+
+stats = pstats.Stats()
+
+for basedir, _, filenames in os.walk(os.getcwd()):
+    for filename in filenames:
+        if fnmatch.fnmatch(filename, 'clcache-*.prof'):
+            path = os.path.join(basedir, filename)
+            print('Reading {}...'.format(path))
+            stats.add(path)
+
+stats.strip_dirs()
+stats.sort_stats('cumulative')
+stats.print_stats()
+


### PR DESCRIPTION
This PR, inspired by #207, adds support for a new `CLCACHE_PROFILE` environment variable. If this variable is set, each clcache invocation generates coverage information in external files. The generated data can be processed into a final report using a little `showprofilereport.py` script.