### PR TITLE
Use scandir instead of listdir if scandir exists

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -25,7 +25,8 @@ VERSION = "3.2.0-dev"
 HashAlgorithm = hashlib.md5
 
 # try to use os.scandir or scandir.scandir
-# fall back to os.walk if not found
+# fall back to os.listdir if not found
+# same for scandir.walk
 try:
     import scandir # pylint: disable=wrong-import-position
     WALK = scandir.walk
@@ -33,8 +34,8 @@ try:
 except ImportError:
     WALK = os.walk
     try:
-        LIST = os.scandir
-    except:
+        LIST = os.scandir # pylint: disable=no-name-in-module
+    except AttributeError:
         LIST = os.listdir
 
 # The codec that is used by clcache to store compiler STDOUR and STDERR in
@@ -79,14 +80,15 @@ def filesBeneath(path):
 
 
 def childDirectories(path, absolute=True):
+    supportsScandir = (LIST != os.listdir)
     for entry in LIST(path):
-        if type(entry) == str:
-            absPath = os.path.join(path, entry)
-            if os.path.isdir(absPath):
-                yield absPath if absolute else entry
-        else:
+        if supportsScandir:
             if entry.is_dir():
                 absPath = os.path.join(path, entry.name)
+                yield absPath if absolute else entry
+        else:
+            absPath = os.path.join(path, entry)
+            if os.path.isdir(absPath):
                 yield absPath if absolute else entry
 
 

--- a/clcache.py
+++ b/clcache.py
@@ -29,8 +29,13 @@ HashAlgorithm = hashlib.md5
 try:
     import scandir # pylint: disable=wrong-import-position
     WALK = scandir.walk
+    LIST = scandir.scandir
 except ImportError:
     WALK = os.walk
+    try:
+        LIST = os.scandir
+    except:
+        LIST = os.listdir
 
 # The codec that is used by clcache to store compiler STDOUR and STDERR in
 # output.txt and stderr.txt.
@@ -74,10 +79,15 @@ def filesBeneath(path):
 
 
 def childDirectories(path, absolute=True):
-    for entry in os.listdir(path):
-        absPath = os.path.join(path, entry)
-        if os.path.isdir(absPath):
-            yield absPath if absolute else entry
+    for entry in LIST(path):
+        if type(entry) == str:
+            absPath = os.path.join(path, entry)
+            if os.path.isdir(absPath):
+                yield absPath if absolute else entry
+        else:
+            if entry.is_dir():
+                absPath = os.path.join(path, entry.name)
+                yield absPath if absolute else entry
 
 
 def normalizeBaseDir(baseDir):

--- a/clcache.py
+++ b/clcache.py
@@ -84,8 +84,7 @@ def childDirectories(path, absolute=True):
     for entry in LIST(path):
         if supportsScandir:
             if entry.is_dir():
-                absPath = os.path.join(path, entry.name)
-                yield absPath if absolute else entry
+                yield entry.path if absolute else entry.name
         else:
             absPath = os.path.join(path, entry)
             if os.path.isdir(absPath):


### PR DESCRIPTION
`scandir` could be found in scandir module or in `os` (since Python 3.5)
According python [docs](https://docs.python.org/3.5/library/os.html#os.listdir) it's much better than old `listdir`.