### PR TITLE
Consistent and safer compiler invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ clcache changelog
  * Bugfix: /MP no longer causes a greatly reduced cache hit rate.
  * Bugfix: In direct mode, clcache will no longer try to access non-existant
    header files (GH #200, GH #209).
+ * Bugfix: Correctly cache and restore stdout/stderr output of compiler when
+   building via the Visual Studio IDE.
  * Add support for the `CL` and `_CL_` environment variables (GH #196).
  * Feature: A new `CLCACHE_PROFILE` environment variable is now recognised
    which can be used to make clcache generate profiling information. The

--- a/clcache.py
+++ b/clcache.py
@@ -1094,8 +1094,7 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, environment
     realCmdline = [compilerBinary] + cmdLine
     printTraceStatement("Invoking real compiler as {}".format(realCmdline))
 
-    if not environment:
-        environment = os.environ
+    environment = environment or os.environ
 
     returnCode = None
     stdout = ''

--- a/clcache.py
+++ b/clcache.py
@@ -1096,6 +1096,11 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, outputAsStr
 
     environment = environment or os.environ
 
+    # Environment variable set by the Visual Studio IDE to make cl.exe write
+    # Unicode output to named pipes instead of stdout. Unset it to make sure
+    # we can catch stdout output.
+    environment.pop("VS_UNICODE_OUTPUT", None)
+
     returnCode = None
     stdout = b''
     stderr = b''

--- a/clcache.py
+++ b/clcache.py
@@ -1090,25 +1090,29 @@ class CommandLineAnalyzer(object):
         return inputFiles, objectFile
 
 
-def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, environment=None):
+def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, outputAsString=True, environment=None):
     realCmdline = [compilerBinary] + cmdLine
     printTraceStatement("Invoking real compiler as {}".format(realCmdline))
 
     environment = environment or os.environ
 
     returnCode = None
-    stdout = ''
-    stderr = ''
+    stdout = b''
+    stderr = b''
     if captureOutput:
         compilerProcess = Popen(realCmdline, stdout=PIPE, stderr=PIPE, env=environment)
-        stdoutBinary, stderrBinary = compilerProcess.communicate()
-        stdout = stdoutBinary.decode(CL_DEFAULT_CODEC)
-        stderr = stderrBinary.decode(CL_DEFAULT_CODEC)
+        stdout, stderr = compilerProcess.communicate()
         returnCode = compilerProcess.returncode
     else:
         returnCode = subprocess.call(realCmdline, env=environment)
 
     printTraceStatement("Real compiler returned code {0:d}".format(returnCode))
+
+    if outputAsString:
+        stdoutString = stdout.decode(CL_DEFAULT_CODEC)
+        stderrString = stderr.decode(CL_DEFAULT_CODEC)
+        return returnCode, stdoutString, stderrString
+
     return returnCode, stdout, stderr
 
 

--- a/clcache.py
+++ b/clcache.py
@@ -359,15 +359,15 @@ class CompilerArtifactsRepository(object):
 
     @staticmethod
     def computeKeyNodirect(compilerBinary, commandLine, environment):
-        ppcmd = [compilerBinary, "/EP"]
-        ppcmd += [arg for arg in commandLine if arg not in ("-c", "/c")]
-        preprocessor = Popen(ppcmd, stdout=PIPE, stderr=PIPE, env=environment)
-        (preprocessedSourceCode, ppStderrBinary) = preprocessor.communicate()
+        ppcmd = ["/EP"] + [arg for arg in commandLine if arg not in ("-c", "/c")]
 
-        if preprocessor.returncode != 0:
+        returnCode, preprocessedSourceCode, ppStderrBinary = \
+            invokeRealCompiler(compilerBinary, ppcmd, captureOutput=True, outputAsString=False, environment=environment)
+
+        if returnCode != 0:
             printBinary(sys.stderr, ppStderrBinary)
             print("clcache: preprocessor failed", file=sys.stderr)
-            sys.exit(preprocessor.returncode)
+            sys.exit(returnCode)
 
         compilerHash = getCompilerHash(compilerBinary)
         normalizedCmdLine = CompilerArtifactsRepository._normalizedCommandLine(commandLine)

--- a/clcache.py
+++ b/clcache.py
@@ -1107,7 +1107,7 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, environment
         stderr = stderrBinary.decode(CL_DEFAULT_CODEC)
         returnCode = compilerProcess.returncode
     else:
-        returnCode = subprocess.call(realCmdline)
+        returnCode = subprocess.call(realCmdline, env=environment)
 
     printTraceStatement("Real compiler returned code {0:d}".format(returnCode))
     return returnCode, stdout, stderr


### PR DESCRIPTION
This refactors some code such that `invokeRealCompiler` is used throughout the program to invoke the real compiler. With that refactoring in place, it was easy to implement a patch which fixes caching and restoring the compiler's stdout/stderr output in case clcache is invoked via the Visual Studio IDE.

This PR is meant to supersede #192 .