### PR TITLE
Atomic manifest updates and multiple entries per manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ clcache changelog
    `CLCACHE_OBJECT_CACHE_TIMEOUT_MS` environment variable.
  * Improvement: Greatly improved concurrency of clcache such that concurrent
    invocations of the tool no longer block each other.
+ * Improvement: Improve hit rate when alternating between two identical
+   versions of the same source file that transitively get different contents of
+   the included files (a common case when switching back and forth between
+   branches).
 
 ## clcache 3.2.0 (2016-07-28)
 

--- a/clcache.py
+++ b/clcache.py
@@ -129,7 +129,14 @@ class Manifest(object):
         return self._entries
 
     def addEntry(self, entry):
-        self._entries.append(entry)
+        """Adds entry at the top of the entries"""
+        self._entries.insert(0, entry)
+
+    def touchEntry(self, entryIndex):
+        """Moves entry in entryIndex position to the top of entries()"""
+        entry = self._entries[entryIndex]
+        self._entries.pop(entryIndex)
+        self._entries.insert(0, entry)
 
 
 class ManifestSection(object):
@@ -1569,7 +1576,7 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
                 cache, objectFile, manifestSection, manifestHash, sourceFile, compiler, cmdLine,
                 Statistics.registerSourceChangedMiss)
 
-        for entry in manifest.entries():
+        for entryIndex, entry in enumerate(manifest.entries()):
             # NOTE: command line options already included in hash for manifest name
             try:
                 includesContentHash = ManifestRepository.getIncludesContentHashForFiles(
@@ -1578,6 +1585,9 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
                 if entry.includesContentHash == includesContentHash:
                     cachekey = entry.objectHash
                     assert cachekey is not None
+                    # Move manifest entry to the top of the entries in the manifest
+                    manifest.touchEntry(entryIndex)
+                    manifestSection.setManifest(manifestHash, manifest)
 
                     return getOrSetArtifacts(
                         cache, cachekey, objectFile, compiler, cmdLine, Statistics.registerEvictedMiss)

--- a/clcache.py
+++ b/clcache.py
@@ -1401,9 +1401,7 @@ def createManifestEntry(manifestHash, includePaths):
 
 
 def createOrUpdateManifest(manifestSection, manifestHash, entry):
-    manifest = manifestSection.getManifest(manifestHash)
-    if manifest is None:
-        manifest = Manifest([])
+    manifest = manifestSection.getManifest(manifestHash) or Manifest()
     manifest.addEntry(entry)
     manifestSection.setManifest(manifestHash, manifest)
     return manifest

--- a/clcache.py
+++ b/clcache.py
@@ -136,9 +136,7 @@ class Manifest(object):
 
     def touchEntry(self, entryIndex):
         """Moves entry in entryIndex position to the top of entries()"""
-        entry = self._entries[entryIndex]
-        self._entries.pop(entryIndex)
-        self._entries.insert(0, entry)
+        self._entries.insert(0, self._entries.pop(entryIndex))
 
 
 class ManifestSection(object):

--- a/clcache.py
+++ b/clcache.py
@@ -1391,12 +1391,11 @@ def processCacheHit(cache, objectFile, cachekey):
 
 
 def createManifestEntry(manifestHash, includePaths):
-    includesWithHash = [[path, getFileHash(path)] for path in includePaths]
-    includesContentHash = ManifestRepository.getIncludesContentHashForHashes(
-        [hash for include, hash in includesWithHash])
+    includesWithHash = {path:getFileHash(path) for path in includePaths}
+    includesContentHash = ManifestRepository.getIncludesContentHashForHashes(includesWithHash.values())
     cachekey = CompilerArtifactsRepository.computeKeyDirect(manifestHash, includesContentHash)
 
-    safeIncludes = [collapseBasedirToPlaceholder(path) for path, contentHash in includesWithHash]
+    safeIncludes = [collapseBasedirToPlaceholder(path) for path in includesWithHash.keys()]
     return ManifestEntry(safeIncludes, includesContentHash, cachekey)
 
 

--- a/clcache.py
+++ b/clcache.py
@@ -122,8 +122,10 @@ class LogicException(Exception):
 
 
 class Manifest(object):
-    def __init__(self, entries):
-        self._entries = entries
+    def __init__(self, entries=None):
+        if entries is None:
+            entries = []
+        self._entries = entries.copy()
 
     def entries(self):
         return self._entries

--- a/clcache.py
+++ b/clcache.py
@@ -144,8 +144,10 @@ class ManifestSection(object):
         return filesBeneath(self.manifestSectionDir)
 
     def setManifest(self, manifestHash, manifest):
+        manifestPath = self.manifestPath(manifestHash)
+        printTraceStatement("Writing manifest with manifestHash = {} to {}".format(manifestHash, manifestPath))
         ensureDirectoryExists(self.manifestSectionDir)
-        with open(self.manifestPath(manifestHash), 'w') as outFile:
+        with open(manifestPath, 'w') as outFile:
             # Converting namedtuple to JSON via OrderedDict preserves key names and keys order
             entries = [e._asdict() for e in manifest.entries()]
             jsonobject = {'entries': entries}

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -233,6 +233,57 @@ class TestHits(unittest.TestCase):
                 newHits = stats.numCacheHits()
             self.assertEqual(newHits, oldHits + 1)
 
+    def testAlternatingHeadersHit(self):
+        with cd(os.path.join(ASSETS_DIR, "hits-and-misses")), tempfile.TemporaryDirectory() as tempDir:
+            cache = clcache.Cache(tempDir)
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            baseCmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 0)
+                self.assertEqual(stats.numCacheEntries(), 0)
+
+            # VERSION 1
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write("#define VERSION 1\n")
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 1)
+                self.assertEqual(stats.numCacheEntries(), 1)
+
+            # VERSION 2
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write("#define VERSION 2\n")
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 2)
+                self.assertEqual(stats.numCacheEntries(), 2)
+
+            # VERSION 1 again
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write("#define VERSION 1\n")
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 1)
+                self.assertEqual(stats.numCacheMisses(), 2)
+                self.assertEqual(stats.numCacheEntries(), 2)
+
+            # VERSION 2 again
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write("#define VERSION 1\n")
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 2)
+                self.assertEqual(stats.numCacheMisses(), 2)
+                self.assertEqual(stats.numCacheEntries(), 2)
+
 
 class TestPrecompiledHeaders(unittest.TestCase):
     def testSampleproject(self):

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -437,6 +437,66 @@ class TestHits(unittest.TestCase):
                 self.assertEqual(stats.numCacheMisses(), 3)
                 self.assertEqual(stats.numCacheEntries(), 1)
 
+    def testAlternatingIncludeOrder(self):
+        with cd(os.path.join(ASSETS_DIR, "hits-and-misses")), tempfile.TemporaryDirectory() as tempDir:
+            cache = clcache.Cache(tempDir)
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            baseCmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
+
+            with open('A.h', 'w') as header:
+                header.write('#define A 1\n')
+            with open('B.h', 'w') as header:
+                header.write('#define B 1\n')
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 0)
+                self.assertEqual(stats.numCacheEntries(), 0)
+
+            # VERSION 1
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write('#include "A.h"\n')
+                f.write('#include "B.h"\n')
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 1)
+                self.assertEqual(stats.numCacheEntries(), 1)
+
+            # VERSION 2
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write('#include "B.h"\n')
+                f.write('#include "A.h"\n')
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 0)
+                self.assertEqual(stats.numCacheMisses(), 2)
+                self.assertEqual(stats.numCacheEntries(), 2)
+
+            # VERSION 1 again
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write('#include "A.h"\n')
+                f.write('#include "B.h"\n')
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 1)
+                self.assertEqual(stats.numCacheMisses(), 2)
+                self.assertEqual(stats.numCacheEntries(), 2)
+
+            # VERSION 2 again
+            with open('stable-source-with-alternating-header.h', 'w') as f:
+                f.write('#include "B.h"\n')
+                f.write('#include "A.h"\n')
+            subprocess.check_call(baseCmd + ["stable-source-with-alternating-header.cpp"], env=customEnv)
+
+            with cache.statistics as stats:
+                self.assertEqual(stats.numCacheHits(), 2)
+                self.assertEqual(stats.numCacheMisses(), 2)
+                self.assertEqual(stats.numCacheEntries(), 2)
+
 
 class TestPrecompiledHeaders(unittest.TestCase):
     def testSampleproject(self):

--- a/tests/integrationtests/hits-and-misses/.gitignore
+++ b/tests/integrationtests/hits-and-misses/.gitignore
@@ -1,0 +1,4 @@
+*.obj
+
+# written by the tests
+stable-source-with-alternating-header.h

--- a/tests/integrationtests/hits-and-misses/stable-source-transitive-header.cpp
+++ b/tests/integrationtests/hits-and-misses/stable-source-transitive-header.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include "transitive-header.h"
+
+int main()
+{
+    std::cout << "A C++ file we compile twice and expect a hit" << std::endl;
+    return 0;
+}

--- a/tests/integrationtests/hits-and-misses/stable-source-with-alternating-header.cpp
+++ b/tests/integrationtests/hits-and-misses/stable-source-with-alternating-header.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include "stable-source-with-alternating-header.h"
+
+int main()
+{
+    std::cout << "A C++ file we compile twice and expect a hit" << std::endl;
+    return 0;
+}

--- a/tests/integrationtests/hits-and-misses/transitive-header.h
+++ b/tests/integrationtests/hits-and-misses/transitive-header.h
@@ -1,0 +1,1 @@
+#include "alternating-header.h"

--- a/unittests.py
+++ b/unittests.py
@@ -904,24 +904,35 @@ class TestParseIncludes(unittest.TestCase):
             r'c:\program files (x86)\microsoft visual studio 12.0\vc\include\concurrencysal.h' in includesSet)
         self.assertTrue(r'' not in includesSet)
 
+
 class TestManifest(unittest.TestCase):
     entry1 = ManifestEntry([r'somepath\myinclude.h'],
-                            "fdde59862785f9f0ad6e661b9b5746b7",
-                            "a649723940dc975ebd17167d29a532f8")
+                           "fdde59862785f9f0ad6e661b9b5746b7",
+                           "a649723940dc975ebd17167d29a532f8")
     entry2 = ManifestEntry([r'somepath\myinclude.h', r'moreincludes.h'],
-                            "474e7fc26a592d84dfa7416c10f036c6",
-                            "8771d7ebcf6c8bd57a3d6485f63e3a89")
+                           "474e7fc26a592d84dfa7416c10f036c6",
+                           "8771d7ebcf6c8bd57a3d6485f63e3a89")
     entries = [entry1, entry2]
 
-    def testCreation(self):
+    def testCreateEmpty(self):
         manifest = Manifest()
         self.assertFalse(manifest.entries())
 
-    def testCreation(self):
+    def testCreateWithEntries(self):
         manifest = Manifest(TestManifest.entries)
         self.assertEqual(TestManifest.entries, manifest.entries())
 
+
     def testAddEntry(self):
+        manifest = Manifest(TestManifest.entries)
+        newEntry = ManifestEntry([r'somepath\myotherinclude.h'],
+                                 "474e7fc26a592d84dfa7416c10f036c6",
+                                 "8771d7ebcf6c8bd57a3d6485f63e3a89")
+        manifest.addEntry(newEntry)
+        self.assertEqual(newEntry, manifest.entries()[0])
+
+
+    def testTouchEntry(self):
         manifest = Manifest(TestManifest.entries)
         self.assertEqual(TestManifest.entry1, manifest.entries()[0])
         manifest.touchEntry(1)

--- a/unittests.py
+++ b/unittests.py
@@ -904,6 +904,29 @@ class TestParseIncludes(unittest.TestCase):
             r'c:\program files (x86)\microsoft visual studio 12.0\vc\include\concurrencysal.h' in includesSet)
         self.assertTrue(r'' not in includesSet)
 
+class TestManifest(unittest.TestCase):
+    entry1 = ManifestEntry([r'somepath\myinclude.h'],
+                            "fdde59862785f9f0ad6e661b9b5746b7",
+                            "a649723940dc975ebd17167d29a532f8")
+    entry2 = ManifestEntry([r'somepath\myinclude.h', r'moreincludes.h'],
+                            "474e7fc26a592d84dfa7416c10f036c6",
+                            "8771d7ebcf6c8bd57a3d6485f63e3a89")
+    entries = [entry1, entry2]
+
+    def testCreation(self):
+        manifest = Manifest()
+        self.assertFalse(manifest.entries())
+
+    def testCreation(self):
+        manifest = Manifest(TestManifest.entries)
+        self.assertEqual(TestManifest.entries, manifest.entries())
+
+    def testAddEntry(self):
+        manifest = Manifest(TestManifest.entries)
+        self.assertEqual(TestManifest.entry1, manifest.entries()[0])
+        manifest.touchEntry(1)
+        self.assertEqual(TestManifest.entry2, manifest.entries()[0])
+
 
 if __name__ == '__main__':
     unittest.TestCase.longMessage = True


### PR DESCRIPTION
A bit late to the party now that #217 is ongoing and will conflict in a few places, nevertheless this fixes a few bugs and concurrency issues.

This PR tries to solve the following issues:
 * Handle alternating include files #212.
 * Fix race condition updating manifest files in postprocess functions (from From https://github.com/frerich/clcache/pull/208#issuecomment-241473339):
> postprocess functions should not assume that the object or manifest cache are in the same state as before. I.e. postprocessNoManifestMiss is run because the manifest didn't exist but by the time it is run the manifest file may exist already. The same applies to postprocessHeaderChangedMiss. That means that the read-update-write of the manifest files needs to be atomic and re-tried by the postprocess functions for each change in the manifests.

If the whole operation of clcache is performed under a lock as proposed in #217 the race condition described above disappears and this PR makes some extra operations (re-reading the manifest file) but still fix the problems with alternating headers.

There are still a few things to consider:
 * In the general case the order of includes in C/C++ is important. There are no tests checking if the file is re-compiled when the order of includes change. For the same reason if a file is included more than once the includesContentHash should be affected.
 * I did not push the release of the lock while computing the current hash of the include files as in #208 because all this is going to change with #217 but it is easy to apply.
 * Reduce the integration tests to the minimum subset (help?).
 * When a matching ManifestEntry is found the entry can be pushed to the top of the Manifest entries to implement LRU.