### PR TITLE
Fixed running TestPrecompiledHeaders.testSampleproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ clcache changelog
 
 ## Upcoming release
 
- * Nothing yet!
+ * Internal: Fixed running integration tests when the clcache source code is
+   stored in a path with spaces (GH #206).
 
 ## clcache 3.3.0 (2016-09-07)
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -559,7 +559,7 @@ class TestHits(unittest.TestCase):
 class TestPrecompiledHeaders(unittest.TestCase):
     def testSampleproject(self):
         with cd(os.path.join(ASSETS_DIR, "precompiled-headers")):
-            cpp = ' '.join(CLCACHE_CMD)
+            cpp = subprocess.list2cmdline(CLCACHE_CMD)
 
             testEnvironment = dict(os.environ, CPP=cpp)
 


### PR DESCRIPTION
The elements of the CLCACHE_CMD list may contain spaces in case the
source code is stored in a directory with spaces in it. In such cases, a
naive ' '.join(..) does not do the right thing and thus this test
failed.

Fix this by using the somewhat unknown (only briefly mentioned in the
documentation) subprocess.list2cmdline function which takes care of
escaping for Windows. It appears this does the right thing.

This resolves #206.