### PR TITLE
Optimized reading compiler output in invokeRealCompiler()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ clcache changelog
    of leaving the cache in a defective state.
  * Internal: Fixed running integration tests when the clcache source code is
    stored in a path with spaces (GH #206).
+ * Improvement: Optimized communicating with real compiler.
 
 ## clcache 3.3.0 (2016-09-07)
 


### PR DESCRIPTION
As it turns out, using two PIPEs with Popen() makes it fork two threads
internally for reading stdout/stderr, and synchronising those threads
seems to take very long. Some Google research suggests that the threads
can be avoided by writing to temporary files.