### PR TITLE
Fix crash when a manifest was evicted but the object is in the cache

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -1432,7 +1432,7 @@ def postprocessUnusableManifestMiss(
     section = cache.compilerArtifactsRepository.section(cachekey)
     with section.lock, cache.statistics.lock, cache.statistics as stats:
         reason(stats)
-        if returnCode == 0 and os.path.exists(objectFile):
+        if returnCode == 0 and os.path.exists(objectFile) and not section.hasEntry(cachekey):
             artifacts = CompilerArtifacts(objectFile, compilerOutput, compilerStderr)
             cleanupRequired = addObjectToCache(stats, cache, section, cachekey, artifacts)
             manifest = createOrUpdateManifest(manifestSection, manifestHash, entry)

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -1106,6 +1106,36 @@ class TestBasedir(unittest.TestCase):
                     self.assertEqual(stats.numCacheHits(), 1)
 
 
+class TestCleanCache(unittest.TestCase):
+    def testEvictedObject(self):
+        with cd(os.path.join(ASSETS_DIR, "hits-and-misses")), tempfile.TemporaryDirectory() as tempDir:
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c", 'hit.cpp']
+
+            # Compile once to insert the object in the cache
+            subprocess.check_call(cmd, env=customEnv)
+
+            # Remove object
+            cache = clcache.Cache(tempDir)
+            cache.compilerArtifactsRepository.clean(0)
+
+            self.assertEqual(subprocess.call(cmd, env=customEnv), 0)
+
+    def testEvictedManifest(self):
+        with cd(os.path.join(ASSETS_DIR, "hits-and-misses")), tempfile.TemporaryDirectory() as tempDir:
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c", 'hit.cpp']
+
+            # Compile once to insert the object in the cache
+            subprocess.check_call(cmd, env=customEnv)
+
+            # Remove manifest
+            cache = clcache.Cache(tempDir)
+            cache.manifestRepository.clean(0)
+
+            self.assertEqual(subprocess.call(cmd, env=customEnv), 0)
+
+
 if __name__ == '__main__':
     unittest.TestCase.longMessage = True
     unittest.main()


### PR DESCRIPTION
Add tests that check if the evicted objects and manifests are handled properly, attempt to reproduce #155.
