### PR TITLE
Handle base dir in get manifest hash

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -97,8 +97,8 @@ def childDirectories(path, absolute=True):
 def normalizeBaseDir(baseDir):
     if baseDir:
         baseDir = os.path.normcase(baseDir)
-        if not baseDir.endswith(os.path.sep):
-            baseDir += os.path.sep
+        if baseDir.endswith(os.path.sep):
+            baseDir = baseDir[0:-1]
         return baseDir
     else:
         # Converts empty string to None

--- a/clcache.py
+++ b/clcache.py
@@ -227,10 +227,12 @@ class ManifestRepository(object):
         compilerHash = getCompilerHash(compilerBinary)
 
         # NOTE: We intentionally do not normalize command line to include
-        # preprocessor options. In direct mode we do not perform
-        # preprocessing before cache lookup, so all parameters are important.
-        # One of the few exceptions to this rule is the /MP switch, which only
-        # defines how many compiler processes are running simultaneusly.
+        # preprocessor options.  In direct mode we do not perform preprocessing
+        # before cache lookup, so all parameters are important.  One of the few
+        # exceptions to this rule is the /MP switch, which only defines how many
+        # compiler processes are running simultaneusly.  Arguments that specify
+        # the compiler where to find the source files are parsed to replace
+        # ocurrences of CLCACHE_BASEDIR by a placeholder.
         commandLine = [arg for arg in commandLine if not arg.startswith("/MP")]
         arguments, inputFiles = CommandLineAnalyzer.parseArgumentsAndInputFiles(commandLine)
         collapseBasedirInCmdPath = lambda path: collapseBasedirToPlaceholder(os.path.normcase(os.path.abspath(path)))

--- a/clcache.py
+++ b/clcache.py
@@ -235,18 +235,18 @@ class ManifestRepository(object):
         arguments, inputFiles = CommandLineAnalyzer.parseArgumentsAndInputFiles(commandLine)
         collapseBasedirInCmdPath = lambda path: collapseBasedirToPlaceholder(os.path.normcase(os.path.abspath(path)))
 
-        commandLineArgs = []
-        projectSpecificArgs = ("AI", "I", "FU")
+        commandLine = []
+        argumentsWithPaths = ("AI", "I", "FU")
         for k in sorted(arguments.keys()):
-            if k in projectSpecificArgs:
-                commandLineArgs.extend(["/" + k + collapseBasedirInCmdPath(arg) for arg in arguments[k]])
+            if k in argumentsWithPaths:
+                commandLine.extend(["/" + k + collapseBasedirInCmdPath(arg) for arg in arguments[k]])
             else:
-                commandLineArgs.extend(["/" + k + arg for arg in arguments[k]])
+                commandLine.extend(["/" + k + arg for arg in arguments[k]])
 
-        commandLineArgs.extend(collapseBasedirInCmdPath(arg) for arg in inputFiles)
+        commandLine.extend(collapseBasedirInCmdPath(arg) for arg in inputFiles)
 
         additionalData = "{}|{}|{}".format(
-            compilerHash, commandLineArgs, ManifestRepository.MANIFEST_FILE_FORMAT_VERSION)
+            compilerHash, commandLine, ManifestRepository.MANIFEST_FILE_FORMAT_VERSION)
         return getFileHash(sourceFile, additionalData)
 
     @staticmethod

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -24,7 +24,7 @@ import clcache
 
 PYTHON_BINARY = sys.executable
 CLCACHE_SCRIPT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "clcache.py")
-ASSETS_DIR = os.path.join("tests", "integrationtests")
+ASSETS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tests", "integrationtests")
 
 # pytest-cov note: subprocesses are coverage tested by default with some limitations
 #   "For subprocess measurement environment variables must make it from the main process to the

--- a/unittests.py
+++ b/unittests.py
@@ -69,14 +69,14 @@ class TestHelperFunctions(unittest.TestCase):
         # Note: raw string literals cannot end in an odd number of backslashes
         # https://docs.python.org/3/faq/design.html#why-can-t-raw-strings-r-strings-end-with-a-backslash
         # So we consistenly use basic literals
-        self.assertEqual(clcache.normalizeBaseDir("c:"), "c:\\")
-        self.assertEqual(clcache.normalizeBaseDir("c:\\projects"), "c:\\projects\\")
+        self.assertEqual(clcache.normalizeBaseDir("c:"), "c:")
+        self.assertEqual(clcache.normalizeBaseDir("c:\\projects"), "c:\\projects")
 
-        self.assertEqual(clcache.normalizeBaseDir("C:\\"), "c:\\")
-        self.assertEqual(clcache.normalizeBaseDir("C:\\Projects\\"), "c:\\projects\\")
+        self.assertEqual(clcache.normalizeBaseDir("C:\\"), "c:")
+        self.assertEqual(clcache.normalizeBaseDir("C:\\Projects\\"), "c:\\projects")
 
-        self.assertEqual(clcache.normalizeBaseDir("c:\\projects with space"), "c:\\projects with space\\")
-        self.assertEqual(clcache.normalizeBaseDir("c:\\projects with ö"), "c:\\projects with ö\\")
+        self.assertEqual(clcache.normalizeBaseDir("c:\\projects with space"), "c:\\projects with space")
+        self.assertEqual(clcache.normalizeBaseDir("c:\\projects with ö"), "c:\\projects with ö")
 
     def testFilesBeneathSimple(self):
         with cd(os.path.join(ASSETS_DIR, "files-beneath")):


### PR DESCRIPTION
CLCACHE_BASEDIR is not used to cleanup the command line when computing the manifest hash. This is a problem because invocations of clcache from different basedirs will create different manifests for equivalent object files.
