### PR TITLE
Introduce memoization to getFileHash

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -13,6 +13,7 @@ import cProfile
 import codecs
 import contextlib
 import errno
+from functools import lru_cache
 import hashlib
 import json
 import multiprocessing
@@ -751,6 +752,7 @@ def getCompilerHash(compilerBinary):
     return hasher.hexdigest()
 
 
+@lru_cache(maxsize=None)
 def getFileHash(filePath, additionalData=None):
     hasher = HashAlgorithm()
     with open(filePath, 'rb') as inFile:


### PR DESCRIPTION
Analysis of profile reports indicates that a large proportion of the
time is spent in getFileHash(), and chances are that this is because
getFileHash() is called repeatedly for the same files. Let's test that
theory by introducing a cache.