### PR TITLE
Switch file hashing to xxhash

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -21,6 +21,14 @@ Installation
 
 Python 3.3+ is required.
 
+Install dependencies
+^^^^^^^^^^^^^^^^^^^^
+
+clcache uses https://pypi.python.org/pypi/xxhash[xxhash] for file hashing.
+Install it via:
+
+    pip install xxhash
+
 Installation via exe
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,9 @@ install:
   - pip install codecov
   - coverage --version
 
+  # Install xxhash python bindings
+  - pip install xxhash
+
 build_script:
   - python clcache.py --help
   - python clcache.py -s

--- a/clcache.py
+++ b/clcache.py
@@ -13,7 +13,6 @@ import cProfile
 import codecs
 import contextlib
 import errno
-import hashlib
 import json
 import multiprocessing
 import os
@@ -21,11 +20,12 @@ import re
 import signal
 import subprocess
 import sys
+import xxhash
 from tempfile import TemporaryFile
 
 VERSION = "3.3.1-dev"
 
-HashAlgorithm = hashlib.md5
+HashAlgorithm = xxhash.xxh64
 
 # try to use os.scandir or scandir.scandir
 # fall back to os.listdir if not found
@@ -192,7 +192,7 @@ class ManifestRepository(object):
     # invalidation, such that a manifest that was stored using the old format is not
     # interpreted using the new format. Instead the old file will not be touched
     # again due to a new manifest hash and is cleaned away after some time.
-    MANIFEST_FILE_FORMAT_VERSION = 6
+    MANIFEST_FILE_FORMAT_VERSION = 7
 
     def __init__(self, manifestsRootDir):
         self._manifestsRootDir = manifestsRootDir


### PR DESCRIPTION
[xxhash](https://pypi.python.org/pypi/xxhash/) was mentioned in [#217](https://github.com/frerich/clcache/pull/217#issuecomment-244132695) and hashing is currently under discussion in #241. I wanted to show how trivial switching to xxhash is and throw it into the discussion again.

For me (ssd, massive parallel compilation) it decreased the compilation time only by 2.4% but others might see more signicifant improvements.

// cc @heremaps/cci @Jimilian @sschuberth