### PR TITLE
Optimistic locking to improve concurrent cache misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ clcache changelog
    exists' error when adding new objects to the cache (GH #155).
  * Improvement: Extended handling of CLCACHE_BASEDIR variable to improve cache
    hit rates when using different build directories.
+ * Improvement: Improved interaction between concurrent clcache invocations
+   when encountering multiple cache misses in parallel; the risk of triggering
+   timeout exceptions is greatly reduced (GH #229).
 
 ## clcache 3.3.1 (2016-10-25)
 

--- a/clcache.py
+++ b/clcache.py
@@ -1609,8 +1609,7 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
             cmdLine = list(cmdLine)
             cmdLine.insert(0, '/showIncludes')
             stripIncludes = True
-    compilerResult = invokeRealCompiler(compiler, cmdLine, captureOutput=True)
-    returnCode, compilerOutput, compilerStderr = compilerResult
+    returnCode, compilerOutput, compilerStderr = invokeRealCompiler(compiler, cmdLine, captureOutput=True)
     if artifactSection is None:
         includePaths, compilerOutput = parseIncludesSet(compilerOutput, sourceFile, stripIncludes)
 
@@ -1636,8 +1635,7 @@ def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
         if artifactSection.hasEntry(cachekey):
             return processCacheHit(cache, objectFile, cachekey)
 
-    compilerResult = invokeRealCompiler(compiler, cmdLine, captureOutput=True, environment=environment)
-    returnCode, compilerOutput, compilerStderr = compilerResult
+    returnCode, compilerOutput, compilerStderr = invokeRealCompiler(compiler, cmdLine, captureOutput=True, environment=environment)
 
     return ensureArtifactsExist(cache, artifactSection, cachekey, Statistics.registerCacheMiss, objectFile, returnCode, compilerOutput, compilerStderr)
 

--- a/clcache.py
+++ b/clcache.py
@@ -1634,13 +1634,13 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
                 except IncludeNotFoundException:
                     pass
 
-            return postprocessUnusableManifestMiss(
-                cache, objectFile, manifestSection, manifestHash, sourceFile, compiler, cmdLine,
-                Statistics.registerHeaderChangedMiss)
+            unusableManifestMissReason = Statistics.registerHeaderChangedMiss
+        else:
+            unusableManifestMissReason = Statistics.registerSourceChangedMiss
 
         return postprocessUnusableManifestMiss(
             cache, objectFile, manifestSection, manifestHash, sourceFile, compiler, cmdLine,
-            Statistics.registerSourceChangedMiss)
+            unusableManifestMissReason)
 
 def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
     cachekey = CompilerArtifactsRepository.computeKeyNodirect(compiler, cmdLine, environment)

--- a/clcache.py
+++ b/clcache.py
@@ -1638,9 +1638,28 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
         else:
             unusableManifestMissReason = Statistics.registerSourceChangedMiss
 
-        return postprocessUnusableManifestMiss(
-            cache, objectFile, manifestSection, manifestHash, sourceFile, compiler, cmdLine,
-            unusableManifestMissReason)
+        stripIncludes = False
+        if '/showIncludes' not in cmdLine:
+            cmdLine = list(cmdLine)
+            cmdLine.insert(0, '/showIncludes')
+            stripIncludes = True
+        returnCode, compilerOutput, compilerStderr = invokeRealCompiler(compiler, cmdLine, captureOutput=True)
+        includePaths, compilerOutput = parseIncludesSet(compilerOutput, sourceFile, stripIncludes)
+
+        entry = createManifestEntry(manifestHash, includePaths)
+        cachekey = entry.objectHash
+
+        cleanupRequired = False
+        section = cache.compilerArtifactsRepository.section(cachekey)
+        with section.lock, cache.statistics.lock, cache.statistics as stats:
+            unusableManifestMissReason(stats)
+            if returnCode == 0 and os.path.exists(objectFile) and not section.hasEntry(cachekey):
+                artifacts = CompilerArtifacts(objectFile, compilerOutput, compilerStderr)
+                cleanupRequired = addObjectToCache(stats, cache, section, cachekey, artifacts)
+                manifest = createOrUpdateManifest(manifestSection, manifestHash, entry)
+                manifestSection.setManifest(manifestHash, manifest)
+
+        return returnCode, compilerOutput, compilerStderr, cleanupRequired
 
 def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
     cachekey = CompilerArtifactsRepository.computeKeyNodirect(compiler, cmdLine, environment)

--- a/clcache.py
+++ b/clcache.py
@@ -1646,10 +1646,6 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
 
 def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
     cachekey = CompilerArtifactsRepository.computeKeyNodirect(compiler, cmdLine, environment)
-    return getOrSetArtifacts(cache, cachekey, objectFile, compiler, cmdLine, Statistics.registerCacheMiss, environment)
-
-
-def getOrSetArtifacts(cache, cachekey, objectFile, compiler, cmdLine, statsField, environment=None):
     artifactSection = cache.compilerArtifactsRepository.section(cachekey)
     cleanupRequired = False
     with artifactSection.lock:
@@ -1659,7 +1655,7 @@ def getOrSetArtifacts(cache, cachekey, objectFile, compiler, cmdLine, statsField
         compilerResult = invokeRealCompiler(compiler, cmdLine, captureOutput=True, environment=environment)
         returnCode, compilerStdout, compilerStderr = compilerResult
         with cache.statistics.lock, cache.statistics as stats:
-            statsField(stats)
+            Statistics.registerCacheMiss(stats)
             if returnCode == 0 and os.path.exists(objectFile):
                 artifacts = CompilerArtifacts(objectFile, compilerStdout, compilerStderr)
                 cleanupRequired = addObjectToCache(stats, cache, artifactSection, cachekey, artifacts)

--- a/clcache.py
+++ b/clcache.py
@@ -1624,8 +1624,8 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
             manifest = createOrUpdateManifest(manifestSection, manifestHash, entry)
             manifestSection.setManifest(manifestHash, manifest)
 
-        section = cache.compilerArtifactsRepository.section(cachekey)
-        return ensureArtifactsExist(cache, section, cachekey, unusableManifestMissReason, objectFile, returnCode, compilerOutput, compilerStderr, addManifest)
+        artifactSection = cache.compilerArtifactsRepository.section(cachekey)
+        return ensureArtifactsExist(cache, artifactSection, cachekey, unusableManifestMissReason, objectFile, returnCode, compilerOutput, compilerStderr, addManifest)
 
 
 def processNoDirect(cache, objectFile, compiler, cmdLine, environment):


### PR DESCRIPTION
This PR attempts to address the issue observed in issue #229 . The theory is that lock timeouts were triggered because -- in direct mode -- clcache holds *two* locks while invoking the real compiler, one manifest section and one artifact section lock. So despite the fact that there are 256 of each category, if a compiler execution takes sufficiently long, it's very well possible that a concurrent clcache invocation tries to access the same manifest *or* the same artifact section -- but times out.

The patch supplied by this PR attempts to address this by implementing a more optimistic locking strategy: in case a cache miss is detected, clcache releases all locks, rebuilds, and then acquires all locks again and checks whether the cache still needs updating. This means that there's a miniscule chance that clcache will compile the same object twice (in case two concurrent invocations are exactly equivalent), but it probably optimizes the common code of concurrent invocations being independent.

This behaviour implemented by basically inlining a lot of code in `processDirect` and `processNoDirect` and then reshuffling things such that the locks are not acquired while calling the real compiler.