### PR TITLE
Fixed off-by-one in runJobs()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ clcache changelog
  * Bugfix: Improved error handling in case statistics files or manifest files
    in the cache are malformed, which could happen when clcache got terminated
    abnormally.
+ * Bugfix: Fixed off-by-one error when compiling source files concurrently,
+   clcache would always launch one concurrent instance more than intended.
 
 ## clcache 3.3.1 (2016-10-25)
 

--- a/clcache.py
+++ b/clcache.py
@@ -1248,7 +1248,7 @@ def runJobs(commands, environment, j=1):
 
     while len(commands):
 
-        while len(running) > j:
+        while len(running) >= j:
             thiscode = waitForAnyProcess(running).returncode
             if thiscode != 0:
                 return thiscode


### PR DESCRIPTION
In the course of discussing GitHub issue #239, @TiloW noticed that the
number of clcache instances launched by the runJobs() function was
always one larger than the number of intended concurrent instances. A
simple off-by-one. This patch fixes it.

Alas, I couldn't think of a nice way to create a test for this since
controlling concurrency is quite difficult and I'd rather have no test
than a flaky test.