### PR TITLE
Use multi threading instead of re-invoking clcache

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -254,7 +254,6 @@ class ManifestRepository(object):
         # compiler processes are running simultaneusly.  Arguments that specify
         # the compiler where to find the source files are parsed to replace
         # ocurrences of CLCACHE_BASEDIR by a placeholder.
-        commandLine = [arg for arg in commandLine if not arg.startswith("/MP")]
         arguments, inputFiles = CommandLineAnalyzer.parseArgumentsAndInputFiles(commandLine)
         collapseBasedirInCmdPath = lambda path: collapseBasedirToPlaceholder(os.path.normcase(os.path.abspath(path)))
 
@@ -1493,7 +1492,7 @@ def processCompileRequest(cache, compiler, args):
         baseCmdLine = []
         setOfSources = set(sourceFiles)
         for arg in cmdLine:
-            if arg not in setOfSources:
+            if not (arg in setOfSources or arg.startswith("/MP")):
                 baseCmdLine.append(arg)
 
         exitCode = 0

--- a/clcache.py
+++ b/clcache.py
@@ -1481,8 +1481,9 @@ def processCompileRequest(cache, compiler, args):
         sourceFiles, objectFiles = CommandLineAnalyzer.analyze(cmdLine)
 
         baseCmdLine = []
+        setOfSources = set(sourceFiles)
         for arg in cmdLine:
-            if arg not in sourceFiles:
+            if arg not in setOfSources:
                 baseCmdLine.append(arg)
 
         exitCode = 0

--- a/clcache.py
+++ b/clcache.py
@@ -1226,28 +1226,6 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, outputAsStr
 
     return returnCode, stdout, stderr
 
-
-# Given a list of Popen objects, removes and returns
-# a completed Popen object.
-#
-# This is a bit inefficient but Python on Windows does not appear to
-# provide any blocking "wait for any process to complete" out of the box.
-def waitForAnyProcess(procs):
-    out = [p for p in procs if p.poll() is not None]
-    if len(out) >= 1:
-        out = out[0]
-        procs.remove(out)
-        return out
-
-    # Damn, none finished yet.
-    # Do a blocking wait for the first one.
-    # This could waste time waiting for one process while others have
-    # already finished :(
-    out = procs.pop(0)
-    out.wait()
-    return out
-
-
 # Returns the amount of jobs which should be run in parallel when
 # invoked in batch mode as determined by the /MP argument
 def jobCount(cmdLine):

--- a/clcache.py
+++ b/clcache.py
@@ -120,6 +120,17 @@ class CacheLockException(Exception):
     pass
 
 
+class CompilerFailedException(Exception):
+    def __init__(self, exitCode, msgErr, msgOut=""):
+        super(CompilerFailedException, self).__init__(msgErr)
+        self.exitCode = exitCode
+        self.msgOut = msgOut
+        self.msgErr = msgErr
+
+    def getReturnTuple(self):
+        return self.exitCode, self.msgErr, self.msgOut, False
+
+
 class LogicException(Exception):
     def __init__(self, message):
         super(LogicException, self).__init__(message)
@@ -431,9 +442,8 @@ class CompilerArtifactsRepository(object):
             invokeRealCompiler(compilerBinary, ppcmd, captureOutput=True, outputAsString=False, environment=environment)
 
         if returnCode != 0:
-            printBinary(sys.stderr, ppStderrBinary)
-            print("clcache: preprocessor failed", file=sys.stderr)
-            sys.exit(returnCode)
+            errMsg = ppStderrBinary.decode(CL_DEFAULT_CODEC) + "\nclcache: preprocessor failed"
+            raise CompilerFailedException(returnCode, errMsg)
 
         compilerHash = getCompilerHash(compilerBinary)
         normalizedCmdLine = CompilerArtifactsRepository._normalizedCommandLine(commandLine)
@@ -1551,6 +1561,8 @@ def processActualCompileRequest(compiler, cmdLine, sourceFile, objectFile, envir
 
     except IncludeNotFoundException:
         return invokeRealCompiler(compiler, cmdLine, environment=environment), False
+    except CompilerFailedException as e:
+        return e.getReturnTuple()
 
 def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
     manifestHash = ManifestRepository.getManifestHash(compiler, cmdLine, sourceFile)

--- a/clcache.py
+++ b/clcache.py
@@ -1531,7 +1531,7 @@ def scheduleJobs(cache, compiler, cmdLine, environment, sourceFiles, objectFiles
         for srcFile, objFile in zip(sourceFiles, objectFiles):
             jobCmdLine = baseCmdLine + [srcFile]
             jobs.append(executor.submit(
-                processActualCompileRequest,
+                processSingleSource,
                 compiler, jobCmdLine, srcFile, objFile, environment))
         for future in concurrent.futures.as_completed(jobs):
             exitCode, out, err, doCleanup = future.result()
@@ -1548,7 +1548,7 @@ def scheduleJobs(cache, compiler, cmdLine, environment, sourceFiles, objectFiles
 
     return exitCode
 
-def processActualCompileRequest(compiler, cmdLine, sourceFile, objectFile, environment):
+def processSingleSource(compiler, cmdLine, sourceFile, objectFile, environment):
     try:
         assert objectFile is not None
         cache = Cache()

--- a/clcache.py
+++ b/clcache.py
@@ -1499,12 +1499,11 @@ def processCompileRequest(cache, compiler, args):
         cleanupRequired = False
         with concurrent.futures.ThreadPoolExecutor(max_workers=jobCount(cmdLine)) as executor:
             jobs = []
-            for i, srcFile in enumerate(sourceFiles):
-                jobCmdLine = list(baseCmdLine)
-                jobCmdLine.append(srcFile)
-                jobs.append(executor.submit( \
-                        processActualCompileRequest, \
-                        compiler, jobCmdLine, srcFile, objectFiles[i], environment))
+            for srcFile, objFile in zip(sourceFiles, objectFiles):
+                jobCmdLine = baseCmdLine + [srcFile]
+                jobs.append(executor.submit(
+                        processActualCompileRequest,
+                        compiler, jobCmdLine, srcFile, objFile, environment))
             for future in concurrent.futures.as_completed(jobs):
                 exitCode, out, err, doCleanup = future.result()
                 printTraceStatement("Finished. Exit code {0:d}".format(exitCode))

--- a/clcache.py
+++ b/clcache.py
@@ -1488,6 +1488,9 @@ def updateCacheStatistics(cache, method):
     with cache.statistics.lock, cache.statistics as stats:
         method(stats)
 
+def printOutAndErr(out, err):
+    printBinary(sys.stdout, out.encode(CL_DEFAULT_CODEC))
+    printBinary(sys.stderr, err.encode(CL_DEFAULT_CODEC))
 
 def processCompileRequest(cache, compiler, args):
     printTraceStatement("Parsing given commandline '{0!s}'".format(args[1:]))
@@ -1513,8 +1516,7 @@ def processCompileRequest(cache, compiler, args):
                         cache, compiler, jobCmdLine, srcFile, objectFiles[i], environment))
             for future in concurrent.futures.as_completed(jobs):
                 exitCode, out, err = future.result()
-                printBinary(sys.stderr, err.encode(CL_DEFAULT_CODEC))
-                printBinary(sys.stdout, out.encode(CL_DEFAULT_CODEC))
+                printOutAndErr(out, err)
 
                 if exitCode != 0:
                     return exitCode
@@ -1546,8 +1548,7 @@ def processCompileRequest(cache, compiler, args):
         updateCacheStatistics(cache, Statistics.registerCallForPreprocessing)
 
     exitCode, out, err = invokeRealCompiler(compiler, args[1:])
-    printBinary(sys.stderr, err.encode(CL_DEFAULT_CODEC))
-    printBinary(sys.stdout, out.encode(CL_DEFAULT_CODEC))
+    printOutAndErr(out, err)
     return exitCode
 
 def processActualCompileRequest(cache, compiler, cmdLine, sourceFile, objectFile, environment):

--- a/clcache.py
+++ b/clcache.py
@@ -1519,6 +1519,7 @@ def processCompileRequest(cache, compiler, args):
                         cache, compiler, jobCmdLine, srcFile, objectFiles[i], environment))
             for future in concurrent.futures.as_completed(jobs):
                 exitCode, out, err, doCleanup = future.result()
+                printTraceStatement("Finished. Exit code {0:d}".format(exitCode))
                 cleanupRequired |= doCleanup
                 printOutAndErr(out, err)
 
@@ -1563,15 +1564,9 @@ def processActualCompileRequest(cache, compiler, cmdLine, sourceFile, objectFile
     try:
         assert objectFile is not None
         if 'CLCACHE_NODIRECT' in os.environ:
-            returnCode, compilerOutput, compilerStderr, cleanupRequired = \
-            processNoDirect(cache, objectFile, compiler, cmdLine, environment)
+            return processNoDirect(cache, objectFile, compiler, cmdLine, environment)
         else:
-            returnCode, compilerOutput, compilerStderr, cleanupRequired = \
-            processDirect(cache, objectFile, compiler, cmdLine, sourceFile)
-
-        printTraceStatement("Finished. Exit code {0:d}".format(returnCode))
-
-        return returnCode, compilerOutput, compilerStderr, cleanupRequired
+            return processDirect(cache, objectFile, compiler, cmdLine, sourceFile)
 
     except IncludeNotFoundException:
         return invokeRealCompiler(compiler, cmdLine, environment=environment), False

--- a/clcache.py
+++ b/clcache.py
@@ -1495,7 +1495,7 @@ def processCompileRequest(cache, compiler, args):
                 jobCmdLine.append(srcFile)
                 jobs.append(executor.submit( \
                         processActualCompileRequest, \
-                        cache, compiler, jobCmdLine, srcFile, objectFiles[i], environment))
+                        compiler, jobCmdLine, srcFile, objectFiles[i], environment))
             for future in concurrent.futures.as_completed(jobs):
                 exitCode, out, err, doCleanup = future.result()
                 printTraceStatement("Finished. Exit code {0:d}".format(exitCode))
@@ -1539,9 +1539,11 @@ def processCompileRequest(cache, compiler, args):
     printOutAndErr(out, err)
     return exitCode
 
-def processActualCompileRequest(cache, compiler, cmdLine, sourceFile, objectFile, environment):
+def processActualCompileRequest(compiler, cmdLine, sourceFile, objectFile, environment):
     try:
         assert objectFile is not None
+        cache = Cache()
+
         if 'CLCACHE_NODIRECT' in os.environ:
             return processNoDirect(cache, objectFile, compiler, cmdLine, environment)
         else:

--- a/clcache.py
+++ b/clcache.py
@@ -74,6 +74,7 @@ CompilerArtifacts = namedtuple('CompilerArtifacts', ['objectFilePath', 'stdout',
 
 def printBinary(stream, rawData):
     stream.buffer.write(rawData)
+    stream.flush()
 
 
 def basenameWithoutExtension(path):

--- a/unittests.py
+++ b/unittests.py
@@ -510,7 +510,7 @@ class TestAnalyzeCommandLine(unittest.TestCase):
 
     def _testFo(self, foArgument, expectedObjectFilepath):
         self._testFull(['/c', foArgument, 'main.cpp'],
-                       ["main.cpp"], expectedObjectFilepath)
+                       ["main.cpp"], [expectedObjectFilepath])
 
     def _testFi(self, fiArgument):
         self._testPreprocessingOutfile(['/c', '/P', fiArgument, 'main.cpp'])
@@ -528,7 +528,7 @@ class TestAnalyzeCommandLine(unittest.TestCase):
         self._testFailure([], NoSourceFileError)
 
     def testSimple(self):
-        self._testFull(["/c", "main.cpp"], ["main.cpp"], "main.obj")
+        self._testFull(["/c", "main.cpp"], ["main.cpp"], ["main.obj"])
 
     def testNoSource(self):
         # No source file has priority over other errors, for consistency
@@ -547,7 +547,7 @@ class TestAnalyzeCommandLine(unittest.TestCase):
     def testOutputFileFromSourcefile(self):
         # For object file
         self._testFull(['/c', 'main.cpp'],
-                       ['main.cpp'], 'main.obj')
+                       ['main.cpp'], ['main.obj'])
         # For preprocessor file
         self._testFailure(['/c', '/P', 'main.cpp'], CalledForPreprocessingError)
 
@@ -634,9 +634,9 @@ class TestAnalyzeCommandLine(unittest.TestCase):
     def testTpTcSimple(self):
         # clcache can handle /Tc or /Tp as long as there is only one of them
         self._testFull(['/c', '/TcMyCcProgram.c'],
-                       ['MyCcProgram.c'], 'MyCcProgram.obj')
+                       ['MyCcProgram.c'], ['MyCcProgram.obj'])
         self._testFull(['/c', '/TpMyCxxProgram.cpp'],
-                       ['MyCxxProgram.cpp'], 'MyCxxProgram.obj')
+                       ['MyCxxProgram.cpp'], ['MyCxxProgram.obj'])
 
     def testLink(self):
         self._testFailure(["main.cpp"], CalledForLinkError)


### PR DESCRIPTION
This idea was coined when we oberserved [rather large increases in build time when comparing `clcache` on cold caches to compiling without `clcache`](https://github.com/frerich/clcache/issues/239#issuecomment-264699884).

One thing supposedly contributing to this increase is that `clcache` re-invokes itself for every source file to be compiled. This is particularly costly when using `pyinstaller`'s `--onefile` flag, as reported in #232.

This PR proposes to switch from re-invoking `clcache` to multi-threading. Some changes had to be made to where output is performed and the command line analyzer was modified to return a list of object files when given multiple source files (this is why the unit tests did change).

Initially, I wanted to also invoke the real compiler at most once per invokation of `clcache` but this is not contained in this PR.

Integration tests failed on my machine even without changing anything on the current master. I did not bother adjusting them. If this is an error on my side, please let me know.

## What does this change do performance-wise?

The following times are obtained on a machine operating on windows 10 where everything takes place on the same SSD and builds are performed in parallel using 4 Cores @ 3.3 GHz.
We are using `CLCACHE_HARDLINK`.

| clcache | this PR | `--onefile` | warm cache | build time |
|---------|------|-----|---------|--------------|
| 0           |-| - |-         | 2:10       |
| 1           |0| 0|0          | 3:40       |
| 1           |0| 0|1          |  1:10     |
| 1           |0| 1|0          | 2:57       |
| 1           |0| 1|1          |  0:32     |
| 1           |1| 0|0          | 2:27       |
| 1           |1| 0|1          |  0:17     |

Edit: I just realized that this table is somewhat confusing: `--onefile = 1` means that I've used `pyinstaller` *without* the flag.

Note that with these changes the compiler is invoked only twice during our build. Thus, it does no longer matter to us whether `--onefile` is used. Apart from multithreading being faster, this would clearly be the more convenient solution for users that do invoke the compiler with many source files (e.g., `msbuild` invokes the compiler once for every target).