### PR TITLE
Folded createOrUpdateManifest()

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -1427,13 +1427,6 @@ def createManifestEntry(manifestHash, includePaths):
     return ManifestEntry(safeIncludes, includesContentHash, cachekey)
 
 
-def createOrUpdateManifest(manifestSection, manifestHash, entry):
-    manifest = manifestSection.getManifest(manifestHash) or Manifest()
-    manifest.addEntry(entry)
-    manifestSection.setManifest(manifestHash, manifest)
-    return manifest
-
-
 def installSignalHandlers():
     # Ignore Ctrl-C and SIGTERM signals to avoid corrupting the cache
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -1628,7 +1621,8 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
         cachekey = entry.objectHash
 
         def addManifest():
-            manifest = createOrUpdateManifest(manifestSection, manifestHash, entry)
+            manifest = manifestSection.getManifest(manifestHash) or Manifest()
+            manifest.addEntry(entry)
             manifestSection.setManifest(manifestHash, manifest)
 
         artifactSection = cache.compilerArtifactsRepository.section(cachekey)


### PR DESCRIPTION
There was just one caller of createOrUpdateManifest(), and it even
duplicates one line of code (adding a manifest to the corresponding
manifest section). Let's fix this by just folding the function. Reduces
the amount of code and gets rid of one indirection.

This supersedes PR #247 