### PR TITLE
Integration tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ build_script:
   - python clcache.py -s
   - pylint --rcfile=.pylintrc clcache.py
   - pylint --rcfile=.pylintrc unittests.py
-  - pylint --rcfile=.pylintrc integrationtests.py
+  - pylint --rcfile=.pylintrc --disable=no-member integrationtests.py
   - pylint --rcfile=.pylintrc performancetests.py
 
 test_script:

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -806,6 +806,17 @@ class TestRunParallel(unittest.TestCase):
                 self.assertEqual(stats.numCacheMisses(), 2)
                 self.assertEqual(stats.numCacheEntries(), 2)
 
+    def testOutput(self):
+        with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
+            sources = glob.glob("*.cpp")
+            clcache.Cache(tempDir)
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
+            mpFlag = "/MP" + str(len(sources))
+            out = subprocess.check_output(cmd + [mpFlag] + sources, env=customEnv).decode("ascii")
+
+            for s in sources:
+                self.assertEqual(out.count(s), 1)
 
 # Compiler calls with multiple sources files at once, e.g.
 # cl file1.c file2.c

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -689,8 +689,7 @@ class TestHeaderMiss(unittest.TestCase):
             self.assertEqual(misses3, misses2)
             self.assertEqual(hits3, hits2+1)
 
-
-class TestRunParallel(unittest.TestCase):
+class RunParallelBase:
     def _zeroStats(self):
         subprocess.check_call(CLCACHE_CMD + ["-z"])
 
@@ -701,10 +700,13 @@ class TestRunParallel(unittest.TestCase):
             print("Starting compilation of {}".format(sourceFile))
             cxxflags = ["/c", "/nologo", "/EHsc"]
             cmd = CLCACHE_CMD + cxxflags + [sourceFile]
-            processes.append(subprocess.Popen(cmd))
+            processes.append(subprocess.Popen(cmd, env=self.env))
 
         for p in processes:
             p.wait()
+
+    def _createEnv(self, directory):
+        return dict(self.env, CLCACHE_DIR=directory)
 
     # Test counting of misses and hits in a parallel environment
     def testParallel(self):
@@ -733,7 +735,7 @@ class TestRunParallel(unittest.TestCase):
         with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
             cache = clcache.Cache(tempDir)
 
-            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            customEnv = self._createEnv(tempDir)
 
             with cache.statistics as stats:
                 self.assertEqual(stats.numCacheHits(), 0)
@@ -762,7 +764,7 @@ class TestRunParallel(unittest.TestCase):
         with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
             cache = clcache.Cache(tempDir)
 
-            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            customEnv = self._createEnv(tempDir)
 
             with cache.statistics as stats:
                 self.assertEqual(stats.numCacheHits(), 0)
@@ -792,13 +794,16 @@ class TestRunParallel(unittest.TestCase):
         with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
             sources = glob.glob("*.cpp")
             clcache.Cache(tempDir)
-            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            customEnv = self._createEnv(tempDir)
             cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
             mpFlag = "/MP" + str(len(sources))
             out = subprocess.check_output(cmd + [mpFlag] + sources, env=customEnv).decode("ascii")
 
             for s in sources:
                 self.assertEqual(out.count(s), 1)
+
+class TestRunParallel(RunParallelBase, unittest.TestCase):
+    env = dict(os.environ)
 
 # Compiler calls with multiple sources files at once, e.g.
 # cl file1.c file2.c
@@ -979,93 +984,31 @@ class TestPreprocessorCalls(unittest.TestCase):
             self.assertEqual(newPreprocessorCalls, oldPreprocessorCalls + i, str(cmd))
 
 
-class TestNoDirectCalls(unittest.TestCase):
+class TestNoDirectCalls(RunParallelBase, unittest.TestCase):
+    env = dict(os.environ, CLCACHE_NODIRECT="1")
+
     def testPreprocessorFailure(self):
         cache = clcache.Cache()
-
         oldStats = copy.copy(cache.statistics)
 
         cmd = CLCACHE_CMD + ["/nologo", "/c", "doesnotexist.cpp"]
-        env = dict(os.environ, CLCACHE_NODIRECT="1")
 
-        self.assertNotEqual(subprocess.call(cmd, env=env), 0)
-
+        self.assertNotEqual(subprocess.call(cmd, env=self.env), 0)
         self.assertEqual(cache.statistics, oldStats)
 
     def testHit(self):
         with cd(os.path.join(ASSETS_DIR, "hits-and-misses")):
             cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c", "hit.cpp"]
-            env = dict(os.environ, CLCACHE_NODIRECT="1")
 
-            self.assertEqual(subprocess.call(cmd, env=env), 0)
+            self.assertEqual(subprocess.call(cmd, env=self.env), 0)
 
             cache = clcache.Cache()
             with cache.statistics as stats:
                 oldHits = stats.numCacheHits()
 
-            self.assertEqual(subprocess.call(cmd, env=env), 0) # This should hit now
+            self.assertEqual(subprocess.call(cmd, env=self.env), 0) # This should hit now
             with cache.statistics as stats:
                 self.assertEqual(stats.numCacheHits(), oldHits + 1)
-
-    def testHitViaMpSequential(self):
-        with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
-            cache = clcache.Cache(tempDir)
-
-            customEnv = dict(os.environ, CLCACHE_DIR=tempDir, CLCACHE_NODIRECT="1")
-
-            with cache.statistics as stats:
-                self.assertEqual(stats.numCacheHits(), 0)
-                self.assertEqual(stats.numCacheMisses(), 0)
-                self.assertEqual(stats.numCacheEntries(), 0)
-
-            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
-
-            # Compile random file, filling cache
-            subprocess.check_call(cmd + ["fibonacci01.cpp"], env=customEnv)
-
-            with cache.statistics as stats:
-                self.assertEqual(stats.numCacheHits(), 0)
-                self.assertEqual(stats.numCacheMisses(), 1)
-                self.assertEqual(stats.numCacheEntries(), 1)
-
-            # Compile same files with specifying /MP, this should hit
-            subprocess.check_call(cmd + ["/MP", "fibonacci01.cpp"], env=customEnv)
-
-            with cache.statistics as stats:
-                self.assertEqual(stats.numCacheHits(), 1)
-                self.assertEqual(stats.numCacheMisses(), 1)
-                self.assertEqual(stats.numCacheEntries(), 1)
-
-    def testHitsViaMpConcurrent(self):
-        with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
-            cache = clcache.Cache(tempDir)
-
-            customEnv = dict(os.environ, CLCACHE_DIR=tempDir, CLCACHE_NODIRECT="1")
-
-            with cache.statistics as stats:
-                self.assertEqual(stats.numCacheHits(), 0)
-                self.assertEqual(stats.numCacheMisses(), 0)
-                self.assertEqual(stats.numCacheEntries(), 0)
-
-            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
-
-            # Compile two random files
-            subprocess.check_call(cmd + ["fibonacci01.cpp"], env=customEnv)
-            subprocess.check_call(cmd + ["fibonacci02.cpp"], env=customEnv)
-
-            with cache.statistics as stats:
-                self.assertEqual(stats.numCacheHits(), 0)
-                self.assertEqual(stats.numCacheMisses(), 2)
-                self.assertEqual(stats.numCacheEntries(), 2)
-
-            # Compile same two files concurrently, this should hit twice.
-            subprocess.check_call(cmd + ["/MP2", "fibonacci01.cpp", "fibonacci02.cpp"], env=customEnv)
-
-            with cache.statistics as stats:
-                self.assertEqual(stats.numCacheHits(), 2)
-                self.assertEqual(stats.numCacheMisses(), 2)
-                self.assertEqual(stats.numCacheEntries(), 2)
-
 
 class TestBasedir(unittest.TestCase):
     def setUp(self):

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import time
 
 import clcache
 
@@ -578,6 +579,11 @@ class TestPrecompiledHeaders(unittest.TestCase):
 
 class TestHeaderChange(unittest.TestCase):
     def _clean(self):
+        # It seems that subprocess.check_output() occasionally returns before
+        # windows fully releases the respective executable.
+        # This pause prevents failing tests because of missing permissions to remove the file.
+        time.sleep(.1)
+
         if os.path.isfile("main.obj"):
             os.remove("main.obj")
         if os.path.isfile("main.exe"):


### PR DESCRIPTION
This reduces duplicated code in the integration tests and adds a tests for invoking the compiler with many source files in parallel. In particular, the command line output is tested.