### PR TITLE
Finer grained signal blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ clcache changelog
 
 ## Upcoming release
 
- * Nothing yet!
+ * Bugfix: Permit interrupting clcache again via Ctrl+C again (GH #261).
 
 ## clcache 4.0.0 (2016-12-15)
 

--- a/clcache.py
+++ b/clcache.py
@@ -177,10 +177,10 @@ class ManifestSection(object):
         manifestPath = self.manifestPath(manifestHash)
         printTraceStatement("Writing manifest with manifestHash = {} to {}".format(manifestHash, manifestPath))
         ensureDirectoryExists(self.manifestSectionDir)
+        # Converting namedtuple to JSON via OrderedDict preserves key names and keys order
+        entries = [e._asdict() for e in manifest.entries()]
+        jsonobject = {'entries': entries}
         with open(manifestPath, 'w') as outFile:
-            # Converting namedtuple to JSON via OrderedDict preserves key names and keys order
-            entries = [e._asdict() for e in manifest.entries()]
-            jsonobject = {'entries': entries}
             json.dump(jsonobject, outFile, sort_keys=True, indent=2)
 
     def getManifest(self, manifestHash):

--- a/clcache.py
+++ b/clcache.py
@@ -116,6 +116,18 @@ def normalizeBaseDir(baseDir):
         return None
 
 
+@contextlib.contextmanager
+def blockedSignals(signals=None):
+    signals = signals or [signal.SIGINT, signal.SIGTERM]
+
+    handlers = [signal.signal(sig, signal.SIG_IGN) for sig in signals]
+    try:
+        yield
+    finally:
+        for sig, handler in zip(signals, handlers):
+            signal.signal(sig, handler)
+
+
 class IncludeNotFoundException(Exception):
     pass
 


### PR DESCRIPTION
In order to avoid that corrupt data (e.g. half of a JSON file) is written to disk when terminating clcache via a `SIGTERM` or `SIGNINT` handler, the script ignored those signals.

However, this means that calls to clcache can no longer be terminated via Ctrl+C. In particular, if a cache miss is encountered and a long-running call to `invokeRealCompiler()` is performed, there's no wayto abort this. This regressed when merging PR #233 .

This patch adjusts the code such that the signals are only blocked during cache-modifying phases, namely:

  * a cache miss in direct mode, after the real compiler finished
  * a cache miss in indirect mode, after the real compiler finished
  * cleaning the cache

By just blocking signals for these (comparatively short) phases, we ensure that no broken object files, no incomplete stdout output and no malformed JSON files are written to disk when pressing Ctrl+C. Furthermore, by blocking the signals on this 'high' level, we ensure that we don't get interrupted between populating the cache and updating the statistics.

Of course, terminating the process by force still may leave the cache in an undefined state so more work is needed to make clcache recover gracefully.

This resolves #261 .