### PR TITLE
Memcached protocol support 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,10 +45,14 @@ install:
   # Install dependencies for clcachesrv such that we can lint the source code
   - pip install -r server\requirements.txt
 
+  # Install pymemcache for memcache storage
+  - pip install pymemcache
+
 build_script:
   - python clcache.py --help
   - python clcache.py -s
   - pylint --rcfile=.pylintrc clcache.py
+  - pylint --rcfile=.pylintrc storage.py
   - pylint --rcfile=.pylintrc unittests.py
   - pylint --rcfile=.pylintrc --disable=no-member integrationtests.py
   - pylint --rcfile=.pylintrc performancetests.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ environment:
     - PYTHON_INSTALL: "C:\\Python35"
 
 install:
+  - appveyor DownloadFile "http://s3.amazonaws.com/downloads.northscale.com/memcached-win64-1.4.4-14.zip" -FileName memcached.zip
+  - 7z x memcached.zip -y
+  - ps: $Memcached = Start-Process memcached\memcached.exe -PassThru
+
   # Make compiler available (use MSVC 2013, 32 bit)
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
 
@@ -48,6 +52,10 @@ install:
   # Install pymemcache for memcache storage
   - pip install pymemcache
 
+cache:
+  - '%LOCALAPPDATA%\pip\Cache -> appveyor.yml'
+  - memcached -> appveyor.yml
+
 build_script:
   - python clcache.py --help
   - python clcache.py -s
@@ -64,7 +72,7 @@ test_script:
   # Run test files via py.test and generate JUnit XML. Then push test results
   # to appveyor. The plugin pytest-cov takes care of coverage.
   - ps: |
-      & py.test --junitxml .\unittests.xml unittests.py --cov=clcache
+      & py.test --junitxml .\unittests.xml unittests.py --cov=clcache --cov=storage
       $testsExitCode = $lastexitcode
       & coverage report
       & coverage xml
@@ -91,6 +99,27 @@ test_script:
       & codecov --no-color -X gcov -F integrationtests -e PYTHON_INSTALL
 
       if ($testsExitCode -ne 0) {exit $testsExitCode}
+
+  - set CLCACHE_MEMCACHED=127.0.0.1:11211
+  - ps: |
+      & py.test --junitxml .\integrationtests.xml integrationtests.py --cov=clcache --cov=storage
+      $testsExitCode = $lastexitcode
+      & coverage report
+      & coverage xml
+
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\integrationtests.xml))
+
+      & codecov --no-color -X gcov -F integrationtests_memcached -e PYTHON_INSTALL
+
+      if ($testsExitCode -ne 0) {exit $testsExitCode}
+
+  - coverage erase
+  - del /Q coverage.xml
+  - set "CLCACHE_MEMCACHED="
+
+on_finish:
+  - ps: Stop-Process -Id $Memcached.Id
 
 on_success:
   # Creates executable with PyInstaller

--- a/clcache.py
+++ b/clcache.py
@@ -500,7 +500,7 @@ class CacheFileStrategy(object):
         self.statistics = Statistics(os.path.join(self.dir, "stats.txt"))
 
     def __str__(self):
-        return "Disk cached at {}".format(self.dir)
+        return "Disk cache at {}".format(self.dir)
 
     @property
     @contextlib.contextmanager
@@ -578,7 +578,7 @@ class Cache(object):
             self.strategy = CacheFileStrategy(cacheDirectory=cacheDirectory)
 
     def __str__(self):
-        self.strategy.__str__(self)
+        return str(self.strategy)
 
     @property
     def lock(self):
@@ -1371,7 +1371,7 @@ clcache statistics:
 
     with cache.statistics as stats, cache.configuration as cfg:
         print(template.format(
-            str(cache()),
+            str(cache),
             stats.currentCacheSize(),
             cfg.maximumCacheSize(),
             stats.numCacheEntries(),

--- a/clcache.py
+++ b/clcache.py
@@ -572,8 +572,8 @@ class CacheFileStrategy(object):
 class Cache(object):
     def __init__(self, cacheDirectory=None):
         if os.environ.get("CLCACHE_MEMCACHED"):
-            from storage import CacheMemcacheStrategy
-            self.strategy = CacheMemcacheStrategy(os.environ.get("CLCACHE_MEMCACHED"), cacheDirectory=cacheDirectory)
+            from storage import CacheFileWithMemcacheFallbackStrategy
+            self.strategy = CacheFileWithMemcacheFallbackStrategy(os.environ.get("CLCACHE_MEMCACHED"), cacheDirectory=cacheDirectory)
         else:
             self.strategy = CacheFileStrategy(cacheDirectory=cacheDirectory)
 

--- a/clcache.py
+++ b/clcache.py
@@ -1733,15 +1733,16 @@ def processNoDirect(cache, objectFile, compiler, cmdLine, environment):
 def ensureArtifactsExist(cache, cachekey, reason, objectFile, compilerResult, extraCallable=None):
     cleanupRequired = False
     returnCode, compilerOutput, compilerStderr = compilerResult
+    correctCompiliation = (returnCode == 0 and os.path.exists(objectFile))
     with cache.lockFor(cachekey):
         if not cache.hasEntry(cachekey):
             with cache.statistics.lock, cache.statistics as stats:
                 reason(stats)
-                if returnCode == 0 and os.path.exists(objectFile):
+                if correctCompiliation:
                     artifacts = CompilerArtifacts(objectFile, compilerOutput, compilerStderr)
                     cleanupRequired = addObjectToCache(stats, cache, cachekey, artifacts)
-                    if extraCallable:
-                        extraCallable()
+            if extraCallable and correctCompiliation:
+                extraCallable()
     return returnCode, compilerOutput, compilerStderr, cleanupRequired
 
 

--- a/clcache.py
+++ b/clcache.py
@@ -573,7 +573,8 @@ class Cache(object):
     def __init__(self, cacheDirectory=None):
         if os.environ.get("CLCACHE_MEMCACHED"):
             from storage import CacheFileWithMemcacheFallbackStrategy
-            self.strategy = CacheFileWithMemcacheFallbackStrategy(os.environ.get("CLCACHE_MEMCACHED"), cacheDirectory=cacheDirectory)
+            self.strategy = CacheFileWithMemcacheFallbackStrategy(os.environ.get("CLCACHE_MEMCACHED"),
+                                                                  cacheDirectory=cacheDirectory)
         else:
             self.strategy = CacheFileStrategy(cacheDirectory=cacheDirectory)
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -21,7 +21,7 @@ import unittest
 import time
 
 import clcache
-
+import pytest
 
 PYTHON_BINARY = sys.executable
 CLCACHE_SCRIPT = os.path.join(os.path.dirname(os.path.realpath(__file__)), "clcache.py")
@@ -911,6 +911,8 @@ class TestClearing(unittest.TestCase):
             self.assertEqual(stats.currentCacheSize(), 0)
             self.assertEqual(stats.numCacheEntries(), 0)
 
+    @pytest.mark.skipif("CLCACHE_MEMCACHED" in os.environ,
+                        reason="clearing on memcached not implemented")
     def testClearPostcondition(self):
         cache = clcache.Cache()
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -1129,7 +1129,7 @@ class TestCleanCache(unittest.TestCase):
 
             # Remove object
             cache = clcache.Cache(tempDir)
-            cache.compilerArtifactsRepository.clean(0)
+            clcache.cleanCache(cache)
 
             self.assertEqual(subprocess.call(cmd, env=customEnv), 0)
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -63,6 +63,15 @@ class TestCommandLineArguments(unittest.TestCase):
             cmd = CLCACHE_CMD + ["-M", value]
             self.assertNotEqual(subprocess.call(cmd), 0, "Command must fail for max size: '" + value + "'")
 
+    def testPrintStatistics(self):
+        with tempfile.TemporaryDirectory() as tempDir:
+            customEnv = dict(os.environ, CLCACHE_DIR=tempDir)
+            cmd = CLCACHE_CMD +  ["-s"]
+            self.assertEqual(
+                subprocess.call(cmd, env=customEnv),
+                0,
+                "Command must be able to print statistics")
+
 
 class TestCompileRuns(unittest.TestCase):
     def testBasicCompileCc(self):

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -1143,7 +1143,7 @@ class TestCleanCache(unittest.TestCase):
 
             # Remove manifest
             cache = clcache.Cache(tempDir)
-            cache.manifestRepository.clean(0)
+            clcache.clearCache(cache)
 
             self.assertEqual(subprocess.call(cmd, env=customEnv), 0)
 

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,153 @@
+from clcache import CacheFileStrategy, getStringHash, printTraceStatement, CompilerArtifacts, \
+    CACHE_COMPILER_OUTPUT_STORAGE_CODEC
+
+from pymemcache.client.base import Client
+from pymemcache.serde import (python_memcache_serializer,
+                              python_memcache_deserializer)
+
+
+class CacheDummyLock(object):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, typ, value, traceback):
+        pass
+
+
+class CacheMemcacheStrategy(object):
+    def __init__(self, server, cacheDirectory=None, manifestPrefix='manifests_', objectPrefix='objects_'):
+        self.fileStrategy = CacheFileStrategy(cacheDirectory=cacheDirectory)
+        # XX Memcache Strategy should be independent
+
+        self.lock = CacheDummyLock()
+        self.local_cache = {}
+        self.local_manifest = {}
+        self.objectPrefix = objectPrefix
+        self.manifestPrefix = manifestPrefix
+
+        self.connect(server)
+
+    def connect(self, server):
+        server = CacheMemcacheStrategy.splitHosts(server)
+        assert len(server) > 0, "%s is a suitable server" % server
+        if len(server) == 1:
+            client_class = Client
+            server = server[0]
+        else:
+            from pymemcache.client.hash import HashClient
+            client_class = HashClient
+            server = server
+        self.client = client_class(server, ignore_exc=True,
+                                   serializer=python_memcache_serializer,
+                                   deserializer=python_memcache_deserializer,
+                                   timeout=5,
+                                   connect_timeout=5,
+                                   key_prefix=(getStringHash(self.fileStrategy.dir) + "_").encode("UTF-8")
+                                   )
+        # XX key_prefix ties fileStrategy cache to memcache entry
+        # because tests currently the integration tests use this to start with clean cache
+        # Prevents from having cache hits in when code base is in different locations
+        # adding code to production just for testing purposes
+
+    def server(self):
+        return self.client.server
+
+    @staticmethod
+    def splitHost(host):
+        port = 11211
+        index = host.rfind(':')
+        if index != -1:
+            host, port = host[:index], int(host[index + 1:])
+        if not host or port > 65535:
+            raise ValueError
+        return host.strip(), port
+
+    @staticmethod
+    def splitHosts(hosts):
+        """
+        :param hosts: A string in the format of HOST:PORT[,HOST:PORT]
+        :return: a list [(HOST, int(PORT)), ..] of tuples that can be consumed by socket.connect()
+        """
+        return [CacheMemcacheStrategy.splitHost(h) for h in hosts.split(',')]
+
+    def __str__(self):
+        return "Remote Memcache @{} object-prefix: {}".format(self.server, self.objectPrefix)
+
+    @property
+    def statistics(self):
+        return self.fileStrategy.statistics
+
+    @property
+    def configuration(self):
+        return self.fileStrategy.configuration
+
+    @staticmethod
+    def lockFor(key):
+        return CacheDummyLock()
+
+    @staticmethod
+    def manifestLockFor(key):
+        return CacheDummyLock()
+
+    def _fetchEntry(self, key):
+        data = self.client.get((self.objectPrefix + key).encode("UTF-8"))
+        if data is not None:
+            self.local_cache[key] = data
+            return True
+        self.local_cache[key] = None
+        return None
+
+    def hasEntry(self, key):
+        return (key in self.local_cache and self.local_cache[key] is not None) or self._fetchEntry(key) is not None
+
+    def getEntry(self, key):
+        if key not in self.local_cache:
+            self._fetchEntry(key)
+        if self.local_cache[key] is None:
+            return None
+        data = self.local_cache[key]
+
+        printTraceStatement("{} remote cache hit for {} dumping into local cache".format(self, key))
+
+        assert len(data) == 3
+
+        # XX this is writing the remote objectfile into the local cache
+        # because the current cache lookup assumes that getEntry gives us an Entry in local cache
+        # so it can copy it to the build destination later
+
+        with self.fileStrategy.lockFor(key):
+            objectFilePath = self.fileStrategy.deserializeCacheEntry(key, data[0])
+
+        return CompilerArtifacts(objectFilePath,
+                                 data[1].decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC),
+                                 data[2].decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
+                                 )
+
+    def setEntry(self, key, artifacts):
+        assert artifacts.objectFilePath
+        with open(artifacts.objectFilePath, 'rb') as objectFile:
+            self.set_ignore_exc(self.objectPrefix + key,
+                                [objectFile.read(),
+                                 artifacts.stdout.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC),
+                                 artifacts.stderr.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)],
+                                )
+
+    def setManifest(self, manifestHash, manifest):
+        self.set_ignore_exc(self.manifestPrefix + manifestHash, manifest)
+
+    def set_ignore_exc(self, key, value):
+        try:
+            self.client.set(key.encode("UTF-8"), value)
+        except Exception:
+            self.client.close()
+            if self.client.ignore_exc:
+                printTraceStatement("Could not set {} in memcache {}".format(key, self.server()))
+                return None
+            raise
+
+    def getManifest(self, manifestHash):
+        return self.client.get((self.manifestPrefix + manifestHash).encode("UTF-8"))
+
+    def clean(self, stats, maximumSize):
+        self.fileStrategy.clean(stats,
+                                maximumSize)


### PR DESCRIPTION
Hi,

last week I had time to follow up on #242. This add memcached protocol support for current master. This PR is not finished, but it is already quite extensive so I want to collect your feedback first before going further.

What is missing at this stage:
- We need a clever way to integrate the integrationtests into appveyor (e.g. spwaning a local memcached and injecting `CLCACHE_MEMCACHED` to ensure CI. They pass with a clear local and remote cache on my machine though
- I would like to make file strategy and memcache strategy independent. For that I would need to change how `set/getEntry` work. ATM the local cache is used as intermediary, so memcache always 'pollutes' the local cache 
`        cachedArtifacts = cache.getEntry(cachekey)  # memcache puts objectFile into local cache
         copyOrLink(cachedArtifacts.objectFilePath, objectFile)  # copy local cache to build folder`
- This is also needed to write more tests for cache logic for `CacheFileWithMemcacheFallbackStrategy` more easily
- Statistics can not distinguish between local and remote file hits/misses. If we want to keep the same approach of only displaying cache hits/miss per client, we can write into a separate `stats.txt` or store these numbers in memcache seperately. Otherwise we can just use memcache's global stats to display. 
- Memcache doesn't need the current Configuration object
- See `# XX inline comments`  

Looking forward to your feedback :)

// cc @heremaps/cci - looks like I'm doing the team notification wrong: @sschuberth @Jimilian @thoulen