### PR TITLE
Make Pylint 1.7.1 happy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -63,7 +63,8 @@ confidence=
 disable=old-ne-operator,zip-builtin-not-iterating,filter-builtin-not-iterating,metaclass-assignment,cmp-method,raw_input-builtin,parameter-unpacking,standarderror-builtin,input-builtin,cmp-builtin,no-absolute-import,round-builtin,coerce-method,file-builtin,import-star-module-level,long-suffix,using-cmp-argument,old-division,reduce-builtin,raising-string,dict-view-method,map-builtin-not-iterating,nonzero-method,buffer-builtin,unicode-builtin,setslice-method,old-octal-literal,range-builtin-not-iterating,apply-builtin,useless-suppression,getslice-method,backtick,intern-builtin,unichr-builtin,unpacking-in-except,next-method-called,dict-iter-method,reload-builtin,coerce-builtin,hex-method,basestring-builtin,old-raise-syntax,execfile-builtin,long-builtin,xrange-builtin,print-statement,delslice-method,oct-method,suppressed-message,indexing-exception,
   missing-docstring,
   unidiomatic-typecheck,
-  no-else-return
+  no-else-return,
+  not-context-manager
 
 [REPORTS]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ confidence=
 # --disable=W"
 disable=old-ne-operator,zip-builtin-not-iterating,filter-builtin-not-iterating,metaclass-assignment,cmp-method,raw_input-builtin,parameter-unpacking,standarderror-builtin,input-builtin,cmp-builtin,no-absolute-import,round-builtin,coerce-method,file-builtin,import-star-module-level,long-suffix,using-cmp-argument,old-division,reduce-builtin,raising-string,dict-view-method,map-builtin-not-iterating,nonzero-method,buffer-builtin,unicode-builtin,setslice-method,old-octal-literal,range-builtin-not-iterating,apply-builtin,useless-suppression,getslice-method,backtick,intern-builtin,unichr-builtin,unpacking-in-except,next-method-called,dict-iter-method,reload-builtin,coerce-builtin,hex-method,basestring-builtin,old-raise-syntax,execfile-builtin,long-builtin,xrange-builtin,print-statement,delslice-method,oct-method,suppressed-message,indexing-exception,
   missing-docstring,
-  unidiomatic-typecheck
+  unidiomatic-typecheck,
+  no-else-return
 
 [REPORTS]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,9 @@ build_script:
   - pylint --rcfile=.pylintrc unittests.py
   - pylint --rcfile=.pylintrc --disable=no-member integrationtests.py
   - pylint --rcfile=.pylintrc performancetests.py
-  - pylint --rcfile=.pylintrc server\clcachesrv.py
+
+  # Disable no-member test here to work around issue in Pylint 1.7.1
+  - pylint --rcfile=.pylintrc --disable=no-member server\clcachesrv.py
 
 test_script:
   # Run test files via py.test and generate JUnit XML. Then push test results

--- a/clcache.py
+++ b/clcache.py
@@ -87,8 +87,8 @@ def basenameWithoutExtension(path):
     return os.path.splitext(basename)[0]
 
 
-def filesBeneath(path):
-    for path, _, filenames in WALK(path):
+def filesBeneath(baseDir):
+    for path, _, filenames in WALK(baseDir):
         for filename in filenames:
             yield os.path.join(path, filename)
 

--- a/clcache.py
+++ b/clcache.py
@@ -1165,7 +1165,7 @@ class CommandLineAnalyzer(object):
             inputFiles += options['Tc']
             compl = True
 
-        if len(inputFiles) == 0:
+        if not inputFiles:
             raise NoSourceFileError()
 
         for opt in ['E', 'EP', 'P']:
@@ -1244,7 +1244,7 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, outputAsStr
 # invoked in batch mode as determined by the /MP argument
 def jobCount(cmdLine):
     mpSwitches = [arg for arg in cmdLine if re.match(r'^/MP(\d+)?$', arg)]
-    if len(mpSwitches) == 0:
+    if not mpSwitches:
         return 1
 
     # the last instance of /MP takes precedence


### PR DESCRIPTION
It appears that pip now installs Pylint 1.7.1 on AppVeyor, which introduced a few additional checks causing PRs to get marked as failures. This PR attempts to make the code base a bit better by either silencing Pylint warnings I do not agree with (or which yield false positives), or by actually patching the code.