### PR TITLE
Cache corruption protection: Atomic replacement of manifests, statistics and object files

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -976,7 +976,7 @@ def copyOrLink(srcFilePath, dstFilePath):
     # lower the chances of corrupting it.
     tempDst = dstFilePath + '.tmp'
     copyfile(srcFilePath, tempDst)
-    os.rename(tempDst, dstFilePath)
+    atomicRename(tempDst, dstFilePath)
 
 
 def myExecutablePath():

--- a/clcache.py
+++ b/clcache.py
@@ -163,11 +163,7 @@ class Manifest(object):
 
     def touchEntry(self, objectHash):
         """Moves entry in entryIndex position to the top of entries()"""
-        entryIndex = 0
-        for i, e in enumerate(self.entries()):
-            if e.objectHash == objectHash:
-                entryIndex = i
-                break
+        entryIndex = next((i for i, e in enumerate(self.entries()) if e.objectHash == objectHash), 0)
         self._entries.insert(0, self._entries.pop(entryIndex))
 
 

--- a/clcache.py
+++ b/clcache.py
@@ -161,8 +161,13 @@ class Manifest(object):
         """Adds entry at the top of the entries"""
         self._entries.insert(0, entry)
 
-    def touchEntry(self, entryIndex):
+    def touchEntry(self, objectHash):
         """Moves entry in entryIndex position to the top of entries()"""
+        entryIndex = 0
+        for i, e in enumerate(self.entries()):
+            if e.objectHash == objectHash:
+                entryIndex = i
+                break
         self._entries.insert(0, self._entries.pop(entryIndex))
 
 
@@ -1681,10 +1686,12 @@ def processDirect(cache, objectFile, compiler, cmdLine, sourceFile):
                 if entry.includesContentHash == includesContentHash:
                     cachekey = entry.objectHash
                     assert cachekey is not None
-                    # Move manifest entry to the top of the entries in the manifest
-                    #manifest.touchEntry(entryIndex)
-                    #with cache.manifestLockFor(manifestHash):
-                        #cache.setManifest(manifestHash, manifest)
+                    if entryIndex > 0:
+                        # Move manifest entry to the top of the entries in the manifest
+                        with cache.manifestLockFor(manifestHash):
+                            manifest = cache.getManifest(manifestHash) or Manifest()
+                            manifest.touchEntry(cachekey)
+                            cache.setManifest(manifestHash, manifest)
 
                     manifestHit = True
                     with cache.lockFor(cachekey):

--- a/clcache.py
+++ b/clcache.py
@@ -1406,17 +1406,17 @@ clcache statistics:
 
 
 def resetStatistics(cache):
-    with cache.statistics as stats:
+    with cache.statistics.lock, cache.statistics as stats:
         stats.resetCounters()
 
 
 def cleanCache(cache):
-    with cache.statistics as stats, cache.configuration as cfg:
+    with cache.lock, cache.statistics as stats, cache.configuration as cfg:
         cache.clean(stats, cfg.maximumCacheSize())
 
 
 def clearCache(cache):
-    with cache.statistics as stats:
+    with cache.lock, cache.statistics as stats:
         cache.clean(stats, 0)
 
 
@@ -1522,25 +1522,21 @@ clcache.py v{}
     cache = Cache()
 
     if len(sys.argv) == 2 and sys.argv[1] == "-s":
-        with cache.lock:
-            printStatistics(cache)
+        printStatistics(cache)
         return 0
 
     if len(sys.argv) == 2 and sys.argv[1] == "-c":
-        with cache.lock:
-            cleanCache(cache)
+        cleanCache(cache)
         print('Cache cleaned')
         return 0
 
     if len(sys.argv) == 2 and sys.argv[1] == "-C":
-        with cache.lock:
-            clearCache(cache)
+        clearCache(cache)
         print('Cache cleared')
         return 0
 
     if len(sys.argv) == 2 and sys.argv[1] == "-z":
-        with cache.lock:
-            resetStatistics(cache)
+        resetStatistics(cache)
         print('Statistics reset')
         return 0
 
@@ -1652,8 +1648,7 @@ def scheduleJobs(cache, compiler, cmdLine, environment, sourceFiles, objectFiles
                 break
 
     if cleanupRequired:
-        with cache.lock:
-            cleanCache(cache)
+        cleanCache(cache)
 
     return exitCode
 

--- a/unittests.py
+++ b/unittests.py
@@ -973,7 +973,7 @@ class TestManifest(unittest.TestCase):
     def testTouchEntry(self):
         manifest = Manifest(TestManifest.entries)
         self.assertEqual(TestManifest.entry1, manifest.entries()[0])
-        manifest.touchEntry(1)
+        manifest.touchEntry("8771d7ebcf6c8bd57a3d6485f63e3a89")
         self.assertEqual(TestManifest.entry2, manifest.entries()[0])
 
 


### PR DESCRIPTION
In this PR the writing of manifests, statistics and object files is done following this pattern:

 * Write to temporary file
 * Call atomic os.replace(tmp, dst)

According to the documentation and what I read on the internet [os.replace(...)](https://docs.python.org/3/library/os.html#os.replace) is an atomic operation, meaning that it can be used to prevent cache corruption if the process is stopped in the middle of a write operation. This should help with the root cause of #263.

In addition, if writing files is atomic, reading those files can be done without locking. The last 3 commits in the PR exploit that fact to avoid locking the manifests or statistics for reading. This may need some more testing, so I am fine taking them to another PR. Theoretically this would make processDirect faster with a cold cache because it doesn't need to lock the manifest to decide that it is a miss. My measurements ~~show a 3% faster compilation times in that case but I am not sure if it is relevant~~ do not show any relevant change in performance. Another benefit of not locking is that `clcache -s` does not hang until it can lock the statistics file.

I tested these changes locally and I didn't notice any problem.