### PR TITLE
[WIP] Investigate why os.replace fails in processNoDirect

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -1338,15 +1338,15 @@ def invokeRealCompiler(compilerBinary, cmdLine, captureOutput=False, outputAsStr
 
             compilerProcess = subprocess.Popen(realCmdline, stdout=stdoutFile, stderr=stderrFile, env=environment)
 
-            try:
-                returnCode = compilerProcess.wait()
-                stdoutFile.seek(0)
-                stdout = stdoutFile.read()
-                stderrFile.seek(0)
-                stderr = stderrFile.read()
-            finally:
-                stdoutFile.close()
-                stderrFile.close()
+        try:
+            returnCode = compilerProcess.wait()
+            stdoutFile.seek(0)
+            stdout = stdoutFile.read()
+            stderrFile.seek(0)
+            stderr = stderrFile.read()
+        finally:
+            stdoutFile.close()
+            stderrFile.close()
     else:
         returnCode = subprocess.call(realCmdline, env=environment)
 

--- a/integrationtests.py
+++ b/integrationtests.py
@@ -807,18 +807,19 @@ class RunParallelBase:
 
     def testOutput(self):
         # type: () -> None
-        with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
-            sources = glob.glob("*.cpp")
-            clcache.Cache(tempDir)
-            customEnv = self._createEnv(tempDir)
-            cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
-            mpFlag = "/MP" + str(len(sources))
-            out = subprocess.check_output(cmd + [mpFlag] + sources, env=customEnv).decode("ascii")
-            # print the output so that it shows up in py.test
-            print(out)
+        for _ in range(100):
+            with cd(os.path.join(ASSETS_DIR, "parallel")), tempfile.TemporaryDirectory() as tempDir:
+                sources = glob.glob("*.cpp")
+                clcache.Cache(tempDir)
+                customEnv = self._createEnv(tempDir)
+                cmd = CLCACHE_CMD + ["/nologo", "/EHsc", "/c"]
+                mpFlag = "/MP" + str(len(sources))
+                out = subprocess.check_output(cmd + [mpFlag] + sources, env=customEnv).decode("ascii")
+                # print the output so that it shows up in py.test
+                print(out)
 
-            for s in sources:
-                self.assertEqual(out.count(s), 1)
+                for s in sources:
+                    self.assertEqual(out.count(s), 1)
 
 class TestRunParallel(RunParallelBase, unittest.TestCase):
     env = dict(os.environ)


### PR DESCRIPTION
Since #286 was merged the test integrationtests.TestNoDirectCalls.testOutput has failed randomly on Python 3.3.

This is a WIP branch to investigate the issue.