### PR TITLE
Replace whole cache entries atomically

### DIFF
--- a/clcache.py
+++ b/clcache.py
@@ -378,12 +378,17 @@ class CompilerArtifactsSection(object):
         cacheEntryDir = self.cacheEntryDir(key)
         # Write new files to a temporary directory
         tempEntryDir = cacheEntryDir + '.new'
+        # Remove any possible left-over in tempEntryDir from previous executions
+        rmtree(tempEntryDir, ignore_errors=True)
         ensureDirectoryExists(tempEntryDir)
         if artifacts.objectFilePath is not None:
-            copyOrLink(artifacts.objectFilePath, os.path.join(tempEntryDir, CompilerArtifactsSection.OBJECT_FILE))
-        self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDOUT_FILE), artifacts.stdout)
+            copyOrLink(artifacts.objectFilePath,
+                       os.path.join(tempEntryDir, CompilerArtifactsSection.OBJECT_FILE))
+        self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDOUT_FILE),
+                                             artifacts.stdout)
         if artifacts.stderr != '':
-            self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDERR_FILE), artifacts.stderr)
+            self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDERR_FILE),
+                                                 artifacts.stderr)
         # Replace the full cache entry atomically
         os.replace(tempEntryDir, cacheEntryDir)
 

--- a/clcache.py
+++ b/clcache.py
@@ -379,27 +379,27 @@ class CompilerArtifactsSection(object):
         ensureDirectoryExists(cacheEntryDir)
         if artifacts.objectFilePath is not None:
             copyOrLink(artifacts.objectFilePath, os.path.join(cacheEntryDir, CompilerArtifactsSection.OBJECT_FILE))
-        self._setCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE), artifacts.stdout)
+        self._setCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE), artifacts.stdout)
         if artifacts.stderr != '':
-            self._setCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE), artifacts.stderr)
+            self._setCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE), artifacts.stderr)
 
     def getEntry(self, key):
         assert self.hasEntry(key)
         cacheEntryDir = self.cacheEntryDir(key)
         return CompilerArtifacts(
             os.path.join(cacheEntryDir, CompilerArtifactsSection.OBJECT_FILE),
-            self._getCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE)),
-            self._getCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE))
+            self._getCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE)),
+            self._getCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE))
             )
 
-    def _getCachedCompilerConsoleOutput(self, key, path):
+    def _getCachedCompilerConsoleOutput(self, path):
         try:
             with open(path, 'rb') as f:
                 return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
         except IOError:
             return ''
 
-    def _setCachedCompilerConsoleOutput(self, key, path, output):
+    def _setCachedCompilerConsoleOutput(self, path, output):
         with open(path, 'wb') as f:
             f.write(output.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
 

--- a/clcache.py
+++ b/clcache.py
@@ -354,6 +354,10 @@ class CacheLock(object):
 
 
 class CompilerArtifactsSection(object):
+    OBJECT_FILE = 'object'
+    STDOUT_FILE = 'output.txt'
+    STDERR_FILE = 'stderr.txt'
+
     def __init__(self, compilerArtifactsSectionDir):
         self.compilerArtifactsSectionDir = compilerArtifactsSectionDir
         self.lock = CacheLock.forPath(self.compilerArtifactsSectionDir)
@@ -365,7 +369,7 @@ class CompilerArtifactsSection(object):
         return childDirectories(self.compilerArtifactsSectionDir, absolute=False)
 
     def cachedObjectName(self, key):
-        return os.path.join(self.cacheEntryDir(key), "object")
+        return os.path.join(self.cacheEntryDir(key), CompilerArtifactsSection.OBJECT_FILE)
 
     def hasEntry(self, key):
         return os.path.exists(self.cacheEntryDir(key))
@@ -374,16 +378,16 @@ class CompilerArtifactsSection(object):
         ensureDirectoryExists(self.cacheEntryDir(key))
         if artifacts.objectFilePath is not None:
             copyOrLink(artifacts.objectFilePath, self.cachedObjectName(key))
-        self._setCachedCompilerConsoleOutput(key, 'output.txt', artifacts.stdout)
+        self._setCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDOUT_FILE, artifacts.stdout)
         if artifacts.stderr != '':
-            self._setCachedCompilerConsoleOutput(key, 'stderr.txt', artifacts.stderr)
+            self._setCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDERR_FILE, artifacts.stderr)
 
     def getEntry(self, key):
         assert self.hasEntry(key)
         return CompilerArtifacts(
             self.cachedObjectName(key),
-            self._getCachedCompilerConsoleOutput(key, 'output.txt'),
-            self._getCachedCompilerConsoleOutput(key, 'stderr.txt')
+            self._getCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDOUT_FILE),
+            self._getCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDERR_FILE)
             )
 
     def _getCachedCompilerConsoleOutput(self, key, fileName):

--- a/clcache.py
+++ b/clcache.py
@@ -376,12 +376,16 @@ class CompilerArtifactsSection(object):
 
     def setEntry(self, key, artifacts):
         cacheEntryDir = self.cacheEntryDir(key)
-        ensureDirectoryExists(cacheEntryDir)
+        # Write new files to a temporary directory
+        tempEntryDir = cacheEntryDir + '.new'
+        ensureDirectoryExists(tempEntryDir)
         if artifacts.objectFilePath is not None:
-            copyOrLink(artifacts.objectFilePath, os.path.join(cacheEntryDir, CompilerArtifactsSection.OBJECT_FILE))
-        self._setCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE), artifacts.stdout)
+            copyOrLink(artifacts.objectFilePath, os.path.join(tempEntryDir, CompilerArtifactsSection.OBJECT_FILE))
+        self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDOUT_FILE), artifacts.stdout)
         if artifacts.stderr != '':
-            self._setCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE), artifacts.stderr)
+            self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDERR_FILE), artifacts.stderr)
+        # Replace the full cache entry atomically
+        os.replace(tempEntryDir, cacheEntryDir)
 
     def getEntry(self, key):
         assert self.hasEntry(key)

--- a/clcache.py
+++ b/clcache.py
@@ -375,32 +375,32 @@ class CompilerArtifactsSection(object):
         return os.path.exists(self.cacheEntryDir(key))
 
     def setEntry(self, key, artifacts):
-        ensureDirectoryExists(self.cacheEntryDir(key))
+        cacheEntryDir = self.cacheEntryDir(key)
+        ensureDirectoryExists(cacheEntryDir)
         if artifacts.objectFilePath is not None:
-            copyOrLink(artifacts.objectFilePath, self.cachedObjectName(key))
-        self._setCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDOUT_FILE, artifacts.stdout)
+            copyOrLink(artifacts.objectFilePath, os.path.join(cacheEntryDir, CompilerArtifactsSection.OBJECT_FILE))
+        self._setCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE), artifacts.stdout)
         if artifacts.stderr != '':
-            self._setCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDERR_FILE, artifacts.stderr)
+            self._setCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE), artifacts.stderr)
 
     def getEntry(self, key):
         assert self.hasEntry(key)
+        cacheEntryDir = self.cacheEntryDir(key)
         return CompilerArtifacts(
-            self.cachedObjectName(key),
-            self._getCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDOUT_FILE),
-            self._getCachedCompilerConsoleOutput(key, CompilerArtifactsSection.STDERR_FILE)
+            os.path.join(cacheEntryDir, CompilerArtifactsSection.OBJECT_FILE),
+            self._getCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE)),
+            self._getCachedCompilerConsoleOutput(key, os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE))
             )
 
-    def _getCachedCompilerConsoleOutput(self, key, fileName):
+    def _getCachedCompilerConsoleOutput(self, key, path):
         try:
-            outputFilePath = os.path.join(self.cacheEntryDir(key), fileName)
-            with open(outputFilePath, 'rb') as f:
+            with open(path, 'rb') as f:
                 return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
         except IOError:
             return ''
 
-    def _setCachedCompilerConsoleOutput(self, key, fileName, output):
-        outputFilePath = os.path.join(self.cacheEntryDir(key), fileName)
-        with open(outputFilePath, 'wb') as f:
+    def _setCachedCompilerConsoleOutput(self, key, path, output):
+        with open(path, 'wb') as f:
             f.write(output.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
 
 

--- a/clcache.py
+++ b/clcache.py
@@ -124,6 +124,17 @@ def atomicWrite(fileName):
     os.replace(tempFileName, fileName)
 
 
+def getCachedCompilerConsoleOutput(path):
+    try:
+        with open(path, 'rb') as f:
+            return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
+    except IOError:
+        return ''
+
+def setCachedCompilerConsoleOutput(path, output):
+    with open(path, 'wb') as f:
+        f.write(output.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
+
 class IncludeNotFoundException(Exception):
     pass
 
@@ -384,11 +395,11 @@ class CompilerArtifactsSection(object):
         if artifacts.objectFilePath is not None:
             copyOrLink(artifacts.objectFilePath,
                        os.path.join(tempEntryDir, CompilerArtifactsSection.OBJECT_FILE))
-        self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDOUT_FILE),
-                                             artifacts.stdout)
+        setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDOUT_FILE),
+                                       artifacts.stdout)
         if artifacts.stderr != '':
-            self._setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDERR_FILE),
-                                                 artifacts.stderr)
+            setCachedCompilerConsoleOutput(os.path.join(tempEntryDir, CompilerArtifactsSection.STDERR_FILE),
+                                           artifacts.stderr)
         # Replace the full cache entry atomically
         os.replace(tempEntryDir, cacheEntryDir)
 
@@ -397,20 +408,9 @@ class CompilerArtifactsSection(object):
         cacheEntryDir = self.cacheEntryDir(key)
         return CompilerArtifacts(
             os.path.join(cacheEntryDir, CompilerArtifactsSection.OBJECT_FILE),
-            self._getCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE)),
-            self._getCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE))
+            getCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDOUT_FILE)),
+            getCachedCompilerConsoleOutput(os.path.join(cacheEntryDir, CompilerArtifactsSection.STDERR_FILE))
             )
-
-    def _getCachedCompilerConsoleOutput(self, path):
-        try:
-            with open(path, 'rb') as f:
-                return f.read().decode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC)
-        except IOError:
-            return ''
-
-    def _setCachedCompilerConsoleOutput(self, path, output):
-        with open(path, 'wb') as f:
-            f.write(output.encode(CACHE_COMPILER_OUTPUT_STORAGE_CODEC))
 
 
 class CompilerArtifactsRepository(object):


### PR DESCRIPTION
This is a follow-up of #286. This time the cache entry directory is replaced atomically.

With these changes all the files written by clcache are replaced atomically on disk, preventing cache corruption when the clcache process is terminated in the middle of a write.