### PR TITLE
Remove signal handlers

### DIFF
--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -20,7 +20,6 @@ import multiprocessing
 import os
 import pickle
 import re
-import signal
 import subprocess
 import sys
 import threading
@@ -1513,15 +1512,7 @@ def createManifestEntry(manifestHash, includePaths):
     return ManifestEntry(safeIncludes, includesContentHash, cachekey)
 
 
-def installSignalHandlers():
-    # Ignore Ctrl-C and SIGTERM signals to avoid corrupting the cache
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-
 def main():
-
-    installSignalHandlers()
-
     if len(sys.argv) == 2 and sys.argv[1] == "--help":
         print("""
 clcache.py v{}


### PR DESCRIPTION
The signal handlers were introduced to avoid cache corruption when the
clcache process is stopped in the middle of a write to the cache
(statistics, manifests or objects). See #233. Even if SIGINT and SIGTERM
were ignored the cache still had a chance to be corrupted in the event
of a SIGTERM (which cannot be ignored).

Since #233 the writing of files to the cache has been improved to
replace the files atomically, reducing the risk of storing corrupted
files in the cache. See pull requests #286, #292 and #296. Therefore
ignoring these signals is not needed anymore.