### PR TITLE
Remove py2exe specific code

### DIFF
--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -992,11 +992,6 @@ def copyOrLink(srcFilePath, dstFilePath):
     os.replace(tempDst, dstFilePath)
 
 
-def myExecutablePath():
-    assert hasattr(sys, "frozen"), "is not frozen by py2exe"
-    return sys.executable.upper()
-
-
 def findCompilerBinary():
     if "CLCACHE_CL" in os.environ:
         path = os.environ["CLCACHE_CL"]
@@ -1005,17 +1000,10 @@ def findCompilerBinary():
 
         return path if os.path.exists(path) else None
 
-    frozenByPy2Exe = hasattr(sys, "frozen")
-
     for p in os.environ["PATH"].split(os.pathsep):
         path = os.path.join(p, "cl.exe")
         if os.path.exists(path):
-            if not frozenByPy2Exe:
-                return path
-
-            # Guard against recursively calling ourselves
-            if path.upper() != myExecutablePath():
-                return path
+            return path
     return None
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,8 +20,8 @@ import tempfile
 import unittest
 import time
 
-from clcache import __main__ as clcache
 import pytest
+from clcache import __main__ as clcache
 
 PYTHON_BINARY = sys.executable
 ASSETS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "integrationtests")


### PR DESCRIPTION
I think this code is not needed anymore since py2exe is not the recommended way
to build the package.