### PR TITLE
 Drop version in directory structure of chocolatey (nuget) target package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ clcache changelog
    entries in case it gets terminated in the middle of copying a file (GH #263).
  * Feature: Added 'monkey' script to simplify integrating clcache with distutils-based
    workflows (GH #284).
+ * Feature: Drop version in directory structure of chocolatey (nuget) target
+   package (GH #318).
 
 ## clcache 4.1.0 (2017-05-23)
 

--- a/clcache.nuspec
+++ b/clcache.nuspec
@@ -27,6 +27,6 @@ Copyright (c)
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
   <files>
-    <file src="clcache-{VERSION}\**" target="clcache-{VERSION}" />
+    <file src="clcache-{VERSION}\**" target="clcache" />
   </files>  
 </package>


### PR DESCRIPTION
Because the tool is used by some MSBuild automation / scripts, having a version in the 'target' directory is not very useful.

For example:
' nuget.exe install clcache -excludeversion -outputdirectory d:\'

Would install clcache binary is located at:

' d:\clcache\clcache-4.4.1\clcache.exe '

This is not very useful as one needs to detect this version, and having it as:

' d:\clcache\clcache\clcache.exe '

Would make more sense.
Note that dropping the '-excludeversion' option would still install the clcache as expected:
' d:\clcache-4.4.1\clcache\clcache.exe '