### PR TITLE
Fix upgrading pip/setuptools/wheel during AppVeyor CI builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ clcache changelog
  * Bugfix: Fixed potential corruption of cache in case clcache is terminated
    while writing a cache entry or updating the cache statistics.
  * Internal: The automatic clcache tests are now executed with Python 3.6, too.
- * Internal: Support for Python 3.3 has been dropped.
+ * Internal: Support for Python 3.3 and Python 3.4 has been dropped.
  * Bugfix: Fixed invoking the real compiler when using the `/Tc` or `/Tp`
    switches (GH #289)
  * Feature: Allow specifying just a file name via `CLCACHE_CL`, the absolute

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,8 +54,10 @@ install:
   # Install the package
   - pip install .
 
-  # Install tool for uploading coverage data to codecov.io
-  - pip install codecov
+  # Install tool for uploading coverage data to codecov.io; select version
+  # 2.0.10 specifically since later versions seem to have a bug due to
+  # which calling 'codecov' in a PowerShell script fails.
+  - pip install https://github.com/codecov/codecov-python/tarball/v2.0.10
   - coverage --version
 
   # Install dependencies for clcachesrv such that we can lint the source code

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - set PATH=%PYTHON_INSTALL%;%PATH%
 
   # Prepend Python scripts to PATH (e.g. pip, py.test, pylint)
-  - set PATH=%PYTHON_INSTALL%\\Scripts;%PATH%
+  - set PATH=%PYTHON_INSTALL%\Scripts;%PATH%
 
   # Check Python version
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,7 @@ test_script:
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\unittests.xml))
 
-      & codecov --no-color -X gcov -F unittests -e PYTHON_INSTALL
+      & codecov --no-color -X gcov -F unittests -e PYTHON_INSTALL -f coverage.xml
 
       if ($testsExitCode -ne 0) {exit $testsExitCode}
 
@@ -113,7 +113,7 @@ test_script:
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\integrationtests.xml))
 
-      & codecov --no-color -X gcov -F integrationtests_memcached -e PYTHON_INSTALL
+      & codecov --no-color -X gcov -F integrationtests_memcached -e PYTHON_INSTALL -f coverage.xml
 
       if ($testsExitCode -ne 0) {exit $testsExitCode}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,9 @@ install:
   - python --version
   
   # Upgrade the Python build tools
-  - pip install -U pip setuptools wheel
+  - python -m pip install --upgrade pip setuptools wheel
 
   # Check pip version
-  - python -m pip install --upgrade pip setuptools wheel
   - pip --version
 
   # Install pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
     # AppVeyor installed Python versions
     # http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON_INSTALL: "C:\\Python34"
     - PYTHON_INSTALL: "C:\\Python35"
     - PYTHON_INSTALL: "C:\\Python36"
 

--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -94,7 +94,7 @@ def filesBeneath(baseDir):
 
 
 def childDirectories(path, absolute=True):
-    supportsScandir = (LIST != os.listdir)
+    supportsScandir = (LIST != os.listdir) # pylint: disable=comparison-with-callable
     for entry in LIST(path):
         if supportsScandir:
             if entry.is_dir():
@@ -163,7 +163,7 @@ class LogicException(Exception):
         return repr(self.message)
 
 
-class Manifest(object):
+class Manifest:
     def __init__(self, entries=None):
         if entries is None:
             entries = []
@@ -182,7 +182,7 @@ class Manifest(object):
         self._entries.insert(0, self._entries.pop(entryIndex))
 
 
-class ManifestSection(object):
+class ManifestSection:
     def __init__(self, manifestSectionDir):
         self.manifestSectionDir = manifestSectionDir
         self.lock = CacheLock.forPath(self.manifestSectionDir)
@@ -231,7 +231,7 @@ def allSectionsLocked(repository):
             section.lock.release()
 
 
-class ManifestRepository(object):
+class ManifestRepository:
     # Bump this counter whenever the current manifest file format changes.
     # E.g. changing the file format from {'oldkey': ...} to {'newkey': ...} requires
     # invalidation, such that a manifest that was stored using the old format is not
@@ -308,7 +308,7 @@ class ManifestRepository(object):
         return HashAlgorithm(','.join(listOfHashes).encode()).hexdigest()
 
 
-class CacheLock(object):
+class CacheLock:
     """ Implements a lock for the object cache which
     can be used in 'with' statements. """
     INFINITE = 0xFFFFFFFF
@@ -364,7 +364,7 @@ class CacheLock(object):
         return CacheLock(lockName, timeoutMs)
 
 
-class CompilerArtifactsSection(object):
+class CompilerArtifactsSection:
     OBJECT_FILE = 'object'
     STDOUT_FILE = 'output.txt'
     STDERR_FILE = 'stderr.txt'
@@ -413,7 +413,7 @@ class CompilerArtifactsSection(object):
             )
 
 
-class CompilerArtifactsRepository(object):
+class CompilerArtifactsRepository:
     def __init__(self, compilerArtifactsRootDir):
         self._compilerArtifactsRootDir = compilerArtifactsRootDir
 
@@ -501,7 +501,7 @@ class CompilerArtifactsRepository(object):
         return [arg for arg in cmdline
                 if not (arg[0] in "/-" and arg[1:].startswith(argsToStrip))]
 
-class CacheFileStrategy(object):
+class CacheFileStrategy:
     def __init__(self, cacheDirectory=None):
         self.dir = cacheDirectory
         if not self.dir:
@@ -591,7 +591,7 @@ class CacheFileStrategy(object):
         stats.setNumCacheEntries(currentCompilerArtifactsCount)
 
 
-class Cache(object):
+class Cache:
     def __init__(self, cacheDirectory=None):
         if os.environ.get("CLCACHE_MEMCACHED"):
             from .storage import CacheFileWithMemcacheFallbackStrategy
@@ -644,7 +644,7 @@ class Cache(object):
         return self.strategy.getManifest(manifestHash)
 
 
-class PersistentJSONDict(object):
+class PersistentJSONDict:
     def __init__(self, fileName):
         self._dirty = False
         self._dict = {}
@@ -676,7 +676,7 @@ class PersistentJSONDict(object):
         return type(self) is type(other) and self.__dict__ == other.__dict__
 
 
-class Configuration(object):
+class Configuration:
     _defaultValues = {"MaximumCacheSize": 1073741824} # 1 GiB
 
     def __init__(self, configurationFile):
@@ -701,7 +701,7 @@ class Configuration(object):
         self._cfg["MaximumCacheSize"] = size
 
 
-class Statistics(object):
+class Statistics:
     CALLS_WITH_INVALID_ARGUMENT = "CallsWithInvalidArgument"
     CALLS_WITHOUT_SOURCE_FILE = "CallsWithoutSourceFile"
     CALLS_WITH_MULTIPLE_SOURCE_FILES = "CallsWithMultipleSourceFiles"
@@ -1026,7 +1026,7 @@ def printTraceStatement(msg: str) -> None:
             print(os.path.join(scriptDir, "clcache.py") + " " + msg)
 
 
-class CommandLineTokenizer(object):
+class CommandLineTokenizer:
     def __init__(self, content):
         self.argv = []
         self._content = content
@@ -1154,7 +1154,7 @@ def extendCommandLineFromEnvironment(cmdLine, environment):
     return cmdLine, remainingEnvironment
 
 
-class Argument(object):
+class Argument:
     def __init__(self, name):
         self.name = name
 
@@ -1192,7 +1192,7 @@ class ArgumentT4(Argument):
     pass
 
 
-class CommandLineAnalyzer(object):
+class CommandLineAnalyzer:
 
     @staticmethod
     def _getParameterizedArgumentType(cmdLineArgument):

--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     WALK = os.walk
     try:
-        LIST = os.scandir # pylint: disable=no-name-in-module
+        LIST = os.scandir # type: ignore # pylint: disable=no-name-in-module
     except AttributeError:
         LIST = os.listdir
 

--- a/clcache/server/__main__.py
+++ b/clcache/server/__main__.py
@@ -10,7 +10,7 @@ import re
 
 import pyuv
 
-class HashCache(object):
+class HashCache:
     def __init__(self, loop, excludePatterns, disableWatching):
         self._loop = loop
         self._watchedDirectories = {}
@@ -66,7 +66,7 @@ class HashCache(object):
         return excluded
 
 
-class Connection(object):
+class Connection:
     def __init__(self, pipe, cache, onCloseCallback):
         self._readBuffer = b''
         self._pipe = pipe
@@ -92,7 +92,7 @@ class Connection(object):
         self._onCloseCallback(self)
 
 
-class PipeServer(object):
+class PipeServer:
     def __init__(self, loop, address, cache):
         self._pipeServer = pyuv.Pipe(loop)
         self._pipeServer.bind(address)

--- a/clcache/storage.py
+++ b/clcache/storage.py
@@ -8,7 +8,7 @@ from .__main__ import CacheFileStrategy, getStringHash, printTraceStatement, Com
     CACHE_COMPILER_OUTPUT_STORAGE_CODEC
 
 
-class CacheDummyLock(object):
+class CacheDummyLock:
     def __enter__(self):
         pass
 
@@ -16,7 +16,7 @@ class CacheDummyLock(object):
         pass
 
 
-class CacheMemcacheStrategy(object):
+class CacheMemcacheStrategy:
     def __init__(self, server, cacheDirectory=None, manifestPrefix='manifests_', objectPrefix='objects_'):
         self.fileStrategy = CacheFileStrategy(cacheDirectory=cacheDirectory)
         # XX Memcache Strategy should be independent
@@ -156,7 +156,7 @@ class CacheMemcacheStrategy(object):
                                 maximumSize)
 
 
-class CacheFileWithMemcacheFallbackStrategy(object):
+class CacheFileWithMemcacheFallbackStrategy:
     def __init__(self, server, cacheDirectory=None, manifestPrefix='manifests_', objectPrefix='objects_'):
         self.localCache = CacheFileStrategy(cacheDirectory=cacheDirectory)
         self.remoteCache = CacheMemcacheStrategy(server, cacheDirectory=cacheDirectory,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,9 +19,9 @@ import sys
 import tempfile
 import unittest
 import time
+import pytest
 
 from clcache import __main__ as clcache
-import pytest
 
 PYTHON_BINARY = sys.executable
 ASSETS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "integrationtests")


### PR DESCRIPTION
The CI builds started failing a while ago, printing:

  pip install -U pip setuptools wheel
  ERROR: To modify pip, please run the following command:
  c:\python34\python.exe -m pip install -U pip setuptools wheel

I.e. it sounds as if one should not invoke 'pip' directly for some
reason but rather load it as a Python module. Looking at the YAML file,
it seems we already did that -- right after the problematic 'pip install
-U' call! So let's drop the direct 'pip' call in favor of the existing
'python -m pip ...' call to fix this.