### PR TITLE
Adding feature to compress cache content

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -71,6 +71,15 @@ CLCACHE_HARDLINK::
     will be created. This is more efficient (faster, and uses less disk space)
     but doesn't work if the cache directory is on a different drive than the
     build directory.
+CLCACHE_COMPRESS::
+    If true, clcache will compress object files it puts in the cache. If the cache
+    was filled without compression it can't be used with compression and vice versa
+    (i.e. you have to clear the cache when changing this setting). The default is false.
+CLCACHE_COMPRESSLEVEL::
+    This setting determines the level at which clcache will compress object files.
+    It only has effect if compression is enabled. The value defaults to 6, and
+    must be no lower than 1 (fastest, worst compression) and no higher than 9
+    (slowest, best compression).
 CLCACHE_NODIRECT::
     Disable direct mode. If this variable is set, clcache will always run
     preprocessor on source file and will hash preprocessor output to get cache

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,7 @@ import multiprocessing
 import os
 import unittest
 import tempfile
+import shutil
 
 from clcache import __main__ as clcache
 
@@ -1111,6 +1112,57 @@ class TestMemcacheStrategy(unittest.TestCase):
             CacheMemcacheStrategy.splitHosts("localhost.local,12345:")
         with self.assertRaises(ValueError):
             CacheMemcacheStrategy.splitHosts("localhost.local;12345:")
+
+
+class TestCompression(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.testDir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove the directory after the test
+        shutil.rmtree(self.testDir)
+        os.environ.clear()
+
+    def assertEntrySizeIsCorrect(self, expectedSize):
+        from clcache.__main__ import copyOrLink
+
+        with cd(self.testDir):
+            srcFilePath = os.path.join(self.testDir, "src")
+            dstFilePath = os.path.join(self.testDir, "dst")
+            with open(srcFilePath, "wb") as f:
+                for i in range(0, 999):
+                    f.write(b"%d" % i)
+            copyOrLink(srcFilePath, dstFilePath, True)
+            size = os.path.getsize(dstFilePath)
+            self.assertEqual(size, expectedSize)
+
+    def testCompression(self):
+        os.environ["CLCACHE_COMPRESS"] = "1"
+        self.assertEntrySizeIsCorrect(1481)
+
+    def testCompressionLevel(self):
+        os.environ["CLCACHE_COMPRESS"] = "1"
+        os.environ["CLCACHE_COMPRESSLEVEL"] = "1"
+        self.assertEntrySizeIsCorrect(1536)
+
+    def testNoCompression(self):
+        self.assertEntrySizeIsCorrect(2887)
+
+    def testDecompression(self):
+        from clcache.__main__ import copyOrLink
+
+        os.environ["CLCACHE_COMPRESS"] = "1"
+        with cd(self.testDir):
+            srcFilePath = os.path.join(self.testDir, "src")
+            tmpFilePath = os.path.join(self.testDir, "tmp")
+            dstFilePath = os.path.join(self.testDir, "dst")
+            with open(srcFilePath, "wb") as f:
+                f.write(b"Content")
+            copyOrLink(srcFilePath, tmpFilePath, True)
+            copyOrLink(tmpFilePath, dstFilePath)
+            self.assertNotEqual(os.path.getsize(srcFilePath), os.path.getsize(tmpFilePath))
+            self.assertEqual(os.path.getsize(srcFilePath), os.path.getsize(dstFilePath))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pull request for issue #327 

I tried to implement the feature similar to ccache. It can be controlled by the following two env variables: 

CLCACHE_COMPRESS
    If true, clcache will compress object files it puts in the cache. If the cache
    was filled without compression it can't be used with compression and vice versa
    (i.e. you have to clear the cache when changing this setting). The default is false.

CLCACHE_COMPRESSLEVEL
    This setting determines the level at which clcache will compress object files.
    It only has effect if compression is enabled. The value defaults to 6, and
    must be no lower than 1 (fastest, worst compression) and no higher than 9
    (slowest, best compression).