### PR TITLE
Replace custom atomicWrite by more robust library call.

### DIFF
--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -6,6 +6,7 @@
 # full text of which is available in the accompanying LICENSE file at the
 # root directory of this project.
 #
+from atomicwrites import atomic_write
 from collections import defaultdict, namedtuple
 from ctypes import windll, wintypes
 from shutil import copyfile, copyfileobj, rmtree, which
@@ -117,14 +118,6 @@ def normalizeBaseDir(baseDir):
         return None
 
 
-@contextlib.contextmanager
-def atomicWrite(fileName):
-    tempFileName = fileName + '.new'
-    with open(tempFileName, 'w') as f:
-        yield f
-    os.replace(tempFileName, fileName)
-
-
 def getCachedCompilerConsoleOutput(path):
     try:
         with open(path, 'rb') as f:
@@ -198,7 +191,7 @@ class ManifestSection:
         manifestPath = self.manifestPath(manifestHash)
         printTraceStatement("Writing manifest with manifestHash = {} to {}".format(manifestHash, manifestPath))
         ensureDirectoryExists(self.manifestSectionDir)
-        with atomicWrite(manifestPath) as outFile:
+        with atomic_write(manifestPath, overwrite=True) as outFile:
             # Converting namedtuple to JSON via OrderedDict preserves key names and keys order
             entries = [e._asdict() for e in manifest.entries()]
             jsonobject = {'entries': entries}
@@ -662,7 +655,7 @@ class PersistentJSONDict:
 
     def save(self):
         if self._dirty:
-            with atomicWrite(self._fileName) as f:
+            with atomic_write(self._fileName, overwrite=True) as f:
                 json.dump(self._dict, f, sort_keys=True, indent=4)
 
     def __setitem__(self, key, value):

--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -6,7 +6,6 @@
 # full text of which is available in the accompanying LICENSE file at the
 # root directory of this project.
 #
-from atomicwrites import atomic_write
 from collections import defaultdict, namedtuple
 from ctypes import windll, wintypes
 from shutil import copyfile, copyfileobj, rmtree, which
@@ -27,6 +26,7 @@ import sys
 import threading
 from tempfile import TemporaryFile
 from typing import Any, List, Tuple, Iterator
+from atomicwrites import atomic_write
 
 VERSION = "4.2.0-dev"
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         'typing; python_version < "3.5"',
         'subprocess.run; python_version < "3.5"',
+        'atomicwrites',
         'pymemcache',
         'pyuv',
     ],


### PR DESCRIPTION
### Issue
We are sometimes seeing following exception when we run our build with many cores:

```
Failed to execute script clcache_main
         Traceback (most recent call last):
           File "clcache_main.py", line 2, in <module>
           File "clcache\__main__.py", line 1596, in main
           File "clcache\__main__.py", line 1623, in processCompileRequest
           File "clcache\__main__.py", line 1675, in scheduleJobs
           File "concurrent\futures\_base.py", line 398, in result
           File "concurrent\futures\_base.py", line 357, in __get_result
           File "concurrent\futures\thread.py", line 55, in run
           File "clcache\__main__.py", line 1696, in processSingleSource
           File "clcache\__main__.py", line 1760, in processDirect
           File "clcache\__main__.py", line 1785, in ensureArtifactsExist
           File "clcache\__main__.py", line 756, in __exit__
           File "clcache\__main__.py", line 666, in save
           File "contextlib.py", line 66, in __exit__
           File "clcache\__main__.py", line 125, in atomicWrite
         PermissionError: [WinError 5] Access is denied: 'XXXX\\stats.txt.new' -> 'XXXX\\stats.txt'
```

Searching a bit makes it look like there is a race condition:
> Anyway, the os.replace docs could state in general that: "[o]n Windows, a PermissionError will be raised if dst is a read-only file, or if either src or dst is currently open, or if src is a directory with an open file".  https://bugs.python.org/issue27886

Looking with that in mind at the `atomicWrite` function:
```
@contextlib.contextmanager
def atomicWrite(fileName):
    tempFileName = fileName + '.new'
    with open(tempFileName, 'w') as f:
# One thread can have a open file handler on the tempFile thats always "stats.txt" ...
        yield f
    os.replace(tempFileName, fileName)
# ... while another thread is calling os.replace() causing PermssionError.
```

### Solution

Replacing the `atomicWrite` function with `atomic_write` from the atomicwrites package seems to solve the issue (https://pypi.org/project/atomicwrites/). The package takes care of such race conditions so we no longer have to think about it.

