### PR TITLE
Fixing pylint finding introduced by pylint 2.2

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -433,10 +433,10 @@ class TestSplitCommandsFile(unittest.TestCase):
         self._genericTest(r'/c /Fo"C:\out dir\" /nologo', ['/c', r'/FoC:\out dir" /nologo'])
 
         # Sane cases of escaping the backslash correctly.
-        self._genericTest(r'/Fo"C:\out dir\\"', [r'/FoC:\out dir' '\\'])
-        self._genericTest(r'/c /Fo"C:\out dir\\"', ['/c', r'/FoC:\out dir' '\\'])
-        self._genericTest(r'/Fo"C:\out dir\\" /nologo', [r'/FoC:\out dir' '\\', r'/nologo'])
-        self._genericTest(r'/c /Fo"C:\out dir\\" /nologo', ['/c', r'/FoC:\out dir' '\\', r'/nologo'])
+        self._genericTest(r'/Fo"C:\out dir\\"', [r'/FoC:\out dir\\'])
+        self._genericTest(r'/c /Fo"C:\out dir\\"', ['/c', r'/FoC:\out dir\\'])
+        self._genericTest(r'/Fo"C:\out dir\\" /nologo', [r'/FoC:\out dir\\', r'/nologo'])
+        self._genericTest(r'/c /Fo"C:\out dir\\" /nologo', ['/c', r'/FoC:\out dir\\', r'/nologo'])
 
     def testVyachselavCase(self):
         self._genericTest(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -433,10 +433,10 @@ class TestSplitCommandsFile(unittest.TestCase):
         self._genericTest(r'/c /Fo"C:\out dir\" /nologo', ['/c', r'/FoC:\out dir" /nologo'])
 
         # Sane cases of escaping the backslash correctly.
-        self._genericTest(r'/Fo"C:\out dir\\"', [r'/FoC:\out dir\\'])
-        self._genericTest(r'/c /Fo"C:\out dir\\"', ['/c', r'/FoC:\out dir\\'])
-        self._genericTest(r'/Fo"C:\out dir\\" /nologo', [r'/FoC:\out dir\\', r'/nologo'])
-        self._genericTest(r'/c /Fo"C:\out dir\\" /nologo', ['/c', r'/FoC:\out dir\\', r'/nologo'])
+        self._genericTest(r'/Fo"C:\out dir\\"', [r'/FoC:\out dir' + '\\'])
+        self._genericTest(r'/c /Fo"C:\out dir\\"', ['/c', r'/FoC:\out dir' + '\\'])
+        self._genericTest(r'/Fo"C:\out dir\\" /nologo', [r'/FoC:\out dir' + '\\', r'/nologo'])
+        self._genericTest(r'/c /Fo"C:\out dir\\" /nologo', ['/c', r'/FoC:\out dir' + '\\', r'/nologo'])
 
     def testVyachselavCase(self):
         self._genericTest(


### PR DESCRIPTION
The unittest always run with the latest pylint version.
The latest version causes new findings in this file:
```
tests\test_unit.py:436:0: W1403: Implicit string concatenation found in list (implicit-str-concat-in-sequence)
tests\test_unit.py:437:0: W1403: Implicit string concatenation found in list (implicit-str-concat-in-sequence)
tests\test_unit.py:438:0: W1403: Implicit string concatenation found in list (implicit-str-concat-in-sequence)
tests\test_unit.py:439:0: W1403: Implicit string concatenation found in list (implicit-str-concat-in-sequence)
```
More details can be found here: http://pylint.pycqa.org/en/latest/whatsnew/2.2.html