### PR TITLE
Add CLCACHE_RECACHE feature

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -65,6 +65,10 @@ CLCACHE_LOG::
 CLCACHE_DISABLE::
     Setting this variable will disable 'clcache.py' completely. The script will
     relay all calls to the real compiler.
+CLCACHE_RECACHE::
+    Setting this variable will prevent clcache from retrieving files stored in its
+    cache. It will still store object files in the cache (possibly overwriting
+    those already present) but they will always be rebuilt using the real compiler.
 CLCACHE_HARDLINK::
     If this variable is set, cached object files won't be copied to their
     final location. Instead, hard links pointing to the cached object files


### PR DESCRIPTION
Just like in ccache, this puts clcache into a "write-only" mode.
Objects will be stored in the cache, but objects already in the cache
will not be reused. The real compiler is always used.

This is useful in CI when you have a release branch that you want to
always use the real compiler, and feature branches that you want to
reap the benefit of the cache generated from the release branch.
In that case you would enable CLCACHE_RECACHE only when building from
the release branch.