### PR TITLE
Support CLCACHE_BASEDIR in nodirect mode

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -86,10 +86,11 @@ CLCACHE_NODIRECT::
     key. Use this if you experience problems with direct mode or if you need
     built-in macroses like \__TIME__ to work correctly.
 CLCACHE_BASEDIR::
-    Has effect only when direct mode is on. Set this to path to root directory
-    of your project. This allows clcache to cache relative paths, so if you
-    move your project to different directory, clcache will produce cache hits as
-    before.
+    Set this to path to root directory of your project. In direct mode, this allows
+    clcache to cache relative paths, so if you move your project to different directory,
+    clcache will produce cache hits as before. When direct mode is disabled, clcache will
+    translate any absolute paths in the preprocessor output into relative paths before
+    computing the hash.
 CLCACHE_OBJECT_CACHE_TIMEOUT_MS::
     Overrides the default ObjectCacheLock timeout (Default is 10 * 1000 ms).
     The ObjectCacheLock is used to give exclusive access to the cache, which is

--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -469,6 +469,11 @@ class CompilerArtifactsRepository:
         compilerHash = getCompilerHash(compilerBinary)
         normalizedCmdLine = CompilerArtifactsRepository._normalizedCommandLine(commandLine)
 
+        if "CLCACHE_BASEDIR" in os.environ:
+            baseDir = normalizeBaseDir(os.environ["CLCACHE_BASEDIR"]).replace("\\", "\\\\").encode("UTF-8")
+            newBaseDir = BASEDIR_REPLACEMENT.encode("UTF-8")
+            preprocessedSourceCode = re.sub(re.escape(baseDir), newBaseDir, preprocessedSourceCode, flags=re.IGNORECASE)
+
         h = HashAlgorithm()
         h.update(compilerHash.encode("UTF-8"))
         h.update(' '.join(normalizedCmdLine).encode("UTF-8"))
@@ -495,7 +500,7 @@ class CompilerArtifactsRepository:
         argsToStrip += ("MP",)
 
         return [arg for arg in cmdline
-                if not (arg[0] in "/-" and arg[1:].startswith(argsToStrip))]
+                if arg[0] in "/-" and not arg[1:].startswith(argsToStrip)]
 
 class CacheFileStrategy:
     def __init__(self, cacheDirectory=None):

--- a/tests/integrationtests/basedir/filemacro.cpp
+++ b/tests/integrationtests/basedir/filemacro.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << __FILE__ << '\n';
+}
+
+


### PR DESCRIPTION
Do a simple case-insensitive find-and-replace to transform absolute
paths into relative paths within the preprocessor output that is used
to compute the hash. This makes CLCACHE_NODIRECT mode usable in the
presence of the `__FILE__` macro.

Fixes a bug in _normalizedCommandLine that caused the source filename
to be included in the hash computation.