### PR TITLE
Enable profiling in scripts provided from `entry_points`

### DIFF
--- a/clcache/__main__.py
+++ b/clcache/__main__.py
@@ -1817,9 +1817,12 @@ def ensureArtifactsExist(cache, cachekey, reason, objectFile, compilerResult, ex
     return returnCode, compilerOutput, compilerStderr, cleanupRequired
 
 
-if __name__ == '__main__':
+def mainWrapper():
     if 'CLCACHE_PROFILE' in os.environ:
         INVOCATION_HASH = getStringHash(','.join(sys.argv))
-        cProfile.run('main()', filename='clcache-{}.prof'.format(INVOCATION_HASH))
+        cProfile.run('import clcache\nclcache.__main__.main()', filename='clcache-{}.prof'.format(INVOCATION_HASH))
     else:
         sys.exit(main())
+
+if __name__ == '__main__':
+    mainWrapper()

--- a/pyinstaller/clcache_main.py
+++ b/pyinstaller/clcache_main.py
@@ -1,2 +1,2 @@
-from clcache.__main__ import main
-main()
+from clcache.__main__ import mainWrapper
+mainWrapper()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     entry_points={
           'console_scripts': [
-              'clcache = clcache.__main__:main',
+              'clcache = clcache.__main__:mainWrapper',
               'clcache-server = clcache.server.__main__:main',
           ]
     },


### PR DESCRIPTION
This fixes #363. Essentially the `clcache.exe` installed from Choco or Pip was used to simply call `main()` skipping the `if CLCACHE_PROFILE` check.

Class and function names may be changed at your discretion.